### PR TITLE
fix power control for multi-host configuration

### DIFF
--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -1421,9 +1421,8 @@ inline void getTrustedModuleRequiredToBoot(
             BMCWEB_LOG_DEBUG(
                 "DBUS response has more than 1 TPM Enable object:{}",
                 subtree.size());
-            // Throw an internal Error and return
-            messages::internalError(asyncResp->res);
-            return;
+	    BMCWEB_LOG_DEBUG(
+                "TPM is not required for booting AMD host. Continuing..");
         }
 
         // Make sure the Dbus response map has a service and objectPath


### PR DESCRIPTION
This changeset disables the check for multiple TPMEnable objects since the condition blocks power control operations when multi-host support is enabled.
