### PR TITLE
log_services: Add AMD PPR for SP7

### DIFF
--- a/redfish-core/src/redfish.cpp
+++ b/redfish-core/src/redfish.cpp
@@ -156,6 +156,11 @@ RedfishService::RedfishService(App& app)
         requestRoutesCrashdumpFile(app);
         requestRoutesCrashdumpClear(app);
         requestRoutesCrashdumpCollect(app);
+        requestRoutesPprService(app);
+        requestRoutesPprGetConfig(app);
+        requestRoutesPprSetConfig(app);
+        requestRoutesPprStatus(app);
+        requestRoutesPprFile(app);
     }
 
     requestRoutesProcessorCollection(app);


### PR DESCRIPTION
Add support for AMD Post Package Repair for SP7 platforms. Changes are merged from SP5 ASPEED 2600 platform and was adopted to the new bmcweb structures.

Example usage:
'''
curl -s -k -u xxx:xxx -H"Content-type: application/json" -X GET https://<BMC IP>/redfish/v1/Systems/system/LogServices/PostPackageRepair/Config

curl -s -k -u xxx:xxx -H"Content-type: application/json" -X PATCH https://<BMC IP>/redfish/v1/Systems/system/LogServices/PostPackageRepair/Config --data '{ "<PPR Config>": true }'

curl -s -k -u xxx:xxx -H"Content-type: application/json" -X GET https://<BMC IP>/redfish/v1/Systems/system/LogServices/PostPackageRepair/Status

curl -s -k -u xxx:xxx -H"Content-type: application/json" -X PATCH https://<BMC IP>/redfish/v1/Systems/system/LogServices/PostPackageRepair/RepairData -d @/<*.json>
'''

Tested:
-Verified in Kenya EVT2 platform