### PR TITLE
Add Error handling for Processor schema

### DIFF
--- a/redfish-core/include/error_messages.hpp
+++ b/redfish-core/include/error_messages.hpp
@@ -1026,6 +1026,18 @@ nlohmann::json propertyMissing(std::string_view arg1);
 void propertyMissing(crow::Response& res, std::string_view arg1);
 
 /**
+ * @brief Formats PropertyNotUpdated message into JSON
+ * Message body: "The property <arg1> is a required property and must be
+ * included in the request."
+ *
+ * @param[in] arg1 Parameter of message that will replace %1 in its body.
+ *
+ * @returns Message PropertyNotUpdated formatted to JSON */
+nlohmann::json propertyNotUpdated(std::string_view arg1);
+
+void propertyNotUpdated(crow::Response& res, std::string_view arg1);
+
+/**
  * @brief Formats ResourceExhaustion message into JSON
  * Message body: "The resource <arg1> was unable to satisfy the request due to
  * unavailability of resources."

--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -205,6 +205,10 @@ inline void getCpuDataByInterface(
                         .jsonValue["ProcessorId"]["IdentificationRegisters"] =
                         "0x" + intToHexString(*value, 16);
                 }
+                else
+                {
+                    messages::propertyNotUpdated(asyncResp->res,"PPIN");
+                }
             }
             else if (property.first == "Microcode")
             {
@@ -440,6 +444,10 @@ inline void getCpuAssetData(std::shared_ptr<bmcweb::AsyncResp> asyncResp,
         {
             asyncResp->res.jsonValue["SerialNumber"] = *serialNumber;
         }
+        else
+        {
+            messages::propertyNotUpdated(asyncResp->res,"SerialNumber");
+        }
 
         if ((model != nullptr) && !model->empty())
         {
@@ -463,9 +471,13 @@ inline void getCpuAssetData(std::shared_ptr<bmcweb::AsyncResp> asyncResp,
             }
         }
 
-        if (partNumber != nullptr)
+        if ((partNumber != nullptr) && (!partNumber->empty()))
         {
             asyncResp->res.jsonValue["PartNumber"] = *partNumber;
+        }
+        else
+        {
+            messages::propertyNotUpdated(asyncResp->res,"PartNumber");
         }
 
         if (sparePartNumber != nullptr && !sparePartNumber->empty())

--- a/redfish-core/src/error_messages.cpp
+++ b/redfish-core/src/error_messages.cpp
@@ -1739,6 +1739,25 @@ void propertyMissing(crow::Response& res, std::string_view arg1)
 
 /**
  * @internal
+ * @brief Formats PropertyNotUpdated message into JSON
+ *
+ * See header file for more information
+ * @endinternal
+ */
+nlohmann::json propertyNotUpdated(std::string_view arg1)
+{
+    return getLog(redfish::registries::base::Index::propertyNotUpdated,
+                  std::to_array({arg1}));
+}
+
+void propertyNotUpdated(crow::Response& res, std::string_view arg1)
+{
+    res.result(boost::beast::http::status::bad_request);
+    addMessageToErrorJson(res.jsonValue, propertyNotUpdated(arg1));
+}
+
+/**
+ * @internal
  * @brief Formats ResourceExhaustion message into JSON
  *
  * See header file for more information


### PR DESCRIPTION
1. Added definition for PropertyNotFound message
    which is already available in the base registry.

2. Populated PropertyNotFound error message when SerialNumber,
    PPIN and PartNumber are not available for processor schema.

Tested fields: Verified in Congo platform.