### PR TITLE
redfish support for CBS Pending Attribute

### DIFF
--- a/redfish-core/include/utils/json_utils.hpp
+++ b/redfish-core/include/utils/json_utils.hpp
@@ -848,5 +848,13 @@ inline void sortJsonArrayByOData(nlohmann::json::array_t& array)
 //  5. null: 4 characters (null)
 uint64_t getEstimatedJsonSize(const nlohmann::json& root);
 
+//Convert json Key to Upper case
+inline std::string toUpperCase(const std::string& input) {
+    std::string result = input;
+    std::transform(result.begin(), result.end(), result.begin(),
+                   [](unsigned char c) { return std::toupper(c); });
+    return result;
+}
+
 } // namespace json_util
 } // namespace redfish

--- a/redfish-core/src/redfish.cpp
+++ b/redfish-core/src/redfish.cpp
@@ -174,6 +174,7 @@ RedfishService::RedfishService(App& app)
 
     requestRoutesBiosService(app);
     requestRoutesBiosReset(app);
+    requestRoutesBiosSettings(app);
 
     if constexpr (BMCWEB_VM_NBDPROXY)
     {


### PR DESCRIPTION
- Added redfish support CBS Pending Attribute When user apply patch to modify any CBS data CBS attributes will shown in URI- redfish/v1/Systems/system/Bios/SD
- Added support for DIMMs data to persistence

Tested fields: Verified using qemu

Upsteam Status : Inappropriate