### PR TITLE
bmcweb: Redfish support for amd-ras config

### DIFF
--- a/redfish-core/include/utils/json_utils.hpp
+++ b/redfish-core/include/utils/json_utils.hpp
@@ -209,8 +209,8 @@ UnpackErrorCode unpackValueWithErrorCode(nlohmann::json& jsonValue,
         value = static_cast<Type>(*jsonPtr);
     }
 
-    else if constexpr ((std::is_unsigned_v<Type>)&&(
-                           !std::is_same_v<bool, Type>))
+    else if constexpr ((std::is_unsigned_v<Type>) &&
+                       (!std::is_same_v<bool, Type>))
     {
         uint64_t* jsonPtr = jsonValue.get_ptr<uint64_t*>();
         if (jsonPtr == nullptr)
@@ -566,8 +566,7 @@ inline bool readJsonHelperObject(nlohmann::json::object_t& obj,
                     std::remove_pointer_t<std::decay_t<decltype(val)>>;
                 return details::unpackValue<ContainedT>(
                     item.second, unpackSpec.key, res, *val);
-            },
-                         unpackSpec.value) &&
+            }, unpackSpec.value) &&
                      result;
 
             unpackSpec.complete = true;
@@ -585,13 +584,11 @@ inline bool readJsonHelperObject(nlohmann::json::object_t& obj,
     {
         if (!perUnpack.complete)
         {
-            bool isOptional = std::visit(
-                [](auto&& val) {
+            bool isOptional = std::visit([](auto&& val) {
                 using ContainedType =
                     std::remove_pointer_t<std::decay_t<decltype(val)>>;
                 return details::IsOptional<ContainedType>::value;
-            },
-                perUnpack.value);
+            }, perUnpack.value);
             if (isOptional)
             {
                 continue;
@@ -848,8 +845,9 @@ inline void sortJsonArrayByOData(nlohmann::json::array_t& array)
 //  5. null: 4 characters (null)
 uint64_t getEstimatedJsonSize(const nlohmann::json& root);
 
-//Convert json Key to Upper case
-inline std::string toUpperCase(const std::string& input) {
+// Convert json Key to Upper case
+inline std::string toUpperCase(const std::string& input)
+{
     std::string result = input;
     std::transform(result.begin(), result.end(), result.begin(),
                    [](unsigned char c) { return std::toupper(c); });


### PR DESCRIPTION
- GET https://<ip>/redfish/v1/Systems/{}/LogServices/Crashdump /Actions/Oem/Crashdump.Configuration
- PATCH https://<ip>/redfish/v1/Systems/{}/LogServices/Crashdump /Actions/Oem/Crashdump.Configuration \ -d $'{"apmlRetries":5}'

Tested fields: Verified using congo platform.
