### PR TITLE
bmcweb: enable OOB AMD PPR

### DIFF
--- a/redfish-core/src/redfish.cpp
+++ b/redfish-core/src/redfish.cpp
@@ -156,12 +156,13 @@ RedfishService::RedfishService(App& app)
         requestRoutesCrashdumpFile(app);
         requestRoutesCrashdumpClear(app);
         requestRoutesCrashdumpCollect(app);
-        requestRoutesPprService(app);
-        requestRoutesPprGetConfig(app);
-        requestRoutesPprSetConfig(app);
-        requestRoutesPprStatus(app);
-        requestRoutesPprFile(app);
     }
+
+    requestRoutesPprService(app);
+    requestRoutesPprGetConfig(app);
+    requestRoutesPprSetConfig(app);
+    requestRoutesPprStatus(app);
+    requestRoutesPprFile(app);
 
     requestRoutesProcessorCollection(app);
     requestRoutesProcessor(app);


### PR DESCRIPTION
AMD Post Package Repair (PPR) was part of the redfish-cpu-log. Removed AMD PPR from redfish-cpu-log and built it with no conditional flag.

Tested:
- verified in Congo