### PR TITLE
 bmcweb: Add error handling for Memory and PCIe

### DIFF
--- a/redfish-core/lib/memory.hpp
+++ b/redfish-core/lib/memory.hpp
@@ -458,14 +458,24 @@ inline void
             (*memorySizeInKB >> 10);
     }
 
-    if (partNumber != nullptr)
+    if (partNumber != nullptr && !partNumber->empty() &&
+        *partNumber != "Not Available")
     {
         asyncResp->res.jsonValue[jsonPtr]["PartNumber"] = *partNumber;
     }
+    else
+    {
+        messages::propertyNotUpdated(asyncResp->res, "PartNumber");
+    }
 
-    if (serialNumber != nullptr)
+    if (serialNumber != nullptr && !serialNumber->empty() &&
+        *serialNumber != "Not Available")
     {
         asyncResp->res.jsonValue[jsonPtr]["SerialNumber"] = *serialNumber;
+    }
+    else
+    {
+        messages::propertyNotUpdated(asyncResp->res, "SerialNumber");
     }
 
     if (manufacturer != nullptr)

--- a/redfish-core/lib/pcie.hpp
+++ b/redfish-core/lib/pcie.hpp
@@ -405,14 +405,24 @@ inline void
             asyncResp->res.jsonValue["Model"] = *model;
         }
 
-        if (partNumber != nullptr)
+        if (partNumber != nullptr && !partNumber->empty() &&
+            *partNumber != "Not Available")
         {
             asyncResp->res.jsonValue["PartNumber"] = *partNumber;
         }
+        else
+        {
+            messages::propertyNotUpdated(asyncResp->res, "PartNumber");
+        }
 
-        if (serialNumber != nullptr)
+        if (serialNumber != nullptr && !serialNumber->empty() &&
+            *serialNumber != "Not Available")
         {
             asyncResp->res.jsonValue["SerialNumber"] = *serialNumber;
+        }
+        else
+        {
+            messages::propertyNotUpdated(asyncResp->res, "SerialNumber");
         }
 
         if (sparePartNumber != nullptr && !sparePartNumber->empty())


### PR DESCRIPTION
- Validate non-null, non-empty, and meaningful values for partnumber and serialnumber.

- Log propertyNotUpdated when values are missing or invalid

Tested fields: Verified in Congo platform.