### PR TITLE
bmcweb: Register new Redfish API for error injection

### DIFF
--- a/redfish-core/src/redfish.cpp
+++ b/redfish-core/src/redfish.cpp
@@ -164,6 +164,8 @@ RedfishService::RedfishService(App& app)
     requestRoutesPprStatus(app);
     requestRoutesPprFile(app);
 
+    requestRoutesOobErrorInjection(app);
+
     requestRoutesProcessorCollection(app);
     requestRoutesProcessor(app);
     requestRoutesOperatingConfigCollection(app);


### PR DESCRIPTION
- Added redfish GET API to display the current error injection mode of the system.

- Added redfish GET API to display the supported error injection types in the system.

    Redfish commands:
    1. curl -s -k -u root:0penBmc -H GET  https://<IP>/redfish/v1/Systems/
       system/Processors/P0/Actions/Oem/Processor.OobErrorInjectionMode

    2. curl -s -k -u root:0penBmc -H GET  https://<IP>/redfish/v1/Systems/
       system/Processors/P0/Actions/Oem/Processor.SupportedErrorTypes

Tested fields: Verified in Congo system.
