### PR TITLE
 Redfish: Memory:  Add MemoryMetrics endpoint

### DIFF
--- a/redfish-core/src/redfish.cpp
+++ b/redfish-core/src/redfish.cpp
@@ -173,6 +173,7 @@ RedfishService::RedfishService(App& app)
     requestRoutesOperatingConfig(app);
     requestRoutesMemoryCollection(app);
     requestRoutesMemory(app);
+    requestRoutesMemoryMetrics(app);
 
     requestRoutesSystems(app);
 


### PR DESCRIPTION
Introduced a new Redfish route at
/redfish/v1/Systems/<str>/Memory/<str>/MemoryMetrics to expose memory metrics for individual DIMMs. The endpoint retrieves and returns CorrectableECCErrorCount via DBus. Also includes route registration in redfish.cpp.

Tested fields: Verified in Congo platform.