### PR TITLE
Redfish: Add Support for Crashdump Config route

### DIFF
--- a/redfish-core/src/redfish.cpp
+++ b/redfish-core/src/redfish.cpp
@@ -157,6 +157,7 @@ RedfishService::RedfishService(App& app)
         requestRoutesCrashdumpFile(app);
         requestRoutesCrashdumpClear(app);
         requestRoutesCrashdumpCollect(app);
+        requestRoutesCrashdumpConfig(app);
     }
 
     requestRoutesPprService(app);


### PR DESCRIPTION
This commit adds the requestRoutesCrashdumpConfig
route to the Redfish service, enabling configuration capabilities for crashdump management.

Tested fields: Verified in Congo platform