### PR TITLE
bmcweb: add Host Power status API for MultiHost

### DIFF
--- a/include/http_utility.hpp
+++ b/include/http_utility.hpp
@@ -108,4 +108,30 @@ inline bool isContentTypeAllowed(std::string_view header, ContentType type,
     return type == allowed;
 }
 
+inline uint8_t getHostNumberFromUrl(const crow::Request& req)
+{
+    uint8_t hostNumber = 0;
+    boost::urls::url_view urlView = req.url();
+
+    for (const auto& param : urlView.params())
+    {
+        if (param.key == "HostNumber" && !param.value.empty())
+        {
+            try
+            {
+                int temp = std::stoi(std::string(param.value));
+                hostNumber = static_cast<uint8_t>(temp);
+            }
+            catch (const std::exception& e)
+            {
+                BMCWEB_LOG_WARNING("Invalid HostNumber format: {}",
+                                   param.value);
+                hostNumber = 0;
+            }
+            break;
+        }
+    }
+    return hostNumber;
+}
+
 } // namespace http_helpers


### PR DESCRIPTION
Added support for to get power status of multiHost

GET https://<ip>/redfish/v1/Systems/system/?HostNumber=1 GET https://<ip>/redfish/v1/Systems/system/?HostNumber=2

Tested fields: Verified on Morocco