### PR TITLE
redfish: Add AmdAifsFailureMatch message

### DIFF
--- a/redfish-core/include/registries/openbmc.json
+++ b/redfish-core/include/registries/openbmc.json
@@ -1662,6 +1662,14 @@
             "ParamTypes": ["string"],
             "Resolution": "None.",
             "Severity": "Critical"
+        },
+        "AmdAifsFailureMatch": {
+            "Description": "Indicates AIFS signature ID match detected",
+            "Message": "AIFS signature ID match detected",
+            "MessageSeverity": "Critical",
+            "NumberOfArgs": 0,
+            "Resolution": "None.",
+            "Severity": "Critical"
         }
     },
     "Name": "OpenBMC Message Registry",

--- a/redfish-core/include/registries/openbmc_message_registry.hpp
+++ b/redfish-core/include/registries/openbmc_message_registry.hpp
@@ -2338,7 +2338,26 @@ constexpr std::array registry =
             },
             "None.",
         }},
-
+    MessageEntry{
+        "SystemPowerOnFailed",
+        {
+            "Indicates that the system failed to power on.",
+            "System Power-On Failed.",
+            "Critical",
+            0,
+            {},
+            "None.",
+        }},
+    MessageEntry{
+        "AmdAifsFailureMatch",
+        {
+            "Indicates AIFS signature ID match detected",
+            "AIFS signature ID match detected",
+            "Critical",
+            0,
+            {},
+            "None.",
+        }},
 };
 
 enum class Index
@@ -2534,5 +2553,6 @@ enum class Index
     systemPowerOffFailed = 188,
     systemPowerOnFailed = 189,
     voltageRegulatorOverheated = 190,
+    AmdAifsFailureMatch = 191,
 };
 } // namespace redfish::registries::openbmc


### PR DESCRIPTION
Introduced a new message entry "AmdAifsFailureMatch" in the OpenBMC message registry JSON and corresponding C++ header. This message indicates detection of an AIFS signature ID match and is marked with Critical severity.

Tested fields: Verified in Congo platform.