### PR TITLE
bmcweb: Add Redfish Post API to log Eventlog entry

### DIFF
--- a/redfish-core/src/redfish.cpp
+++ b/redfish-core/src/redfish.cpp
@@ -112,6 +112,7 @@ RedfishService::RedfishService(App& app)
     requestRoutesPostCodesClear(app);
     requestRoutesPostCodesEntry(app);
     requestRoutesPostCodesEntryCollection(app);
+    requestRoutesEventLogEntriesPost(app);
 
     if constexpr (BMCWEB_REDFISH_DUMP_LOG)
     {


### PR DESCRIPTION
Added new Redfish Post API to log Eventlog entry
POST https://ip/redfish/v1/Managers/bmc/LogServices/EventLog/Actions
 /Oem/OpenBMC.LogService.CreateLogEntry
 -d '{"Message": "Test new log entry message", "Severity": 2,
 "AdditionalData": {"REDFISH_MESSAGE_ID": "OpenBMC.0.1.ServiceFailure",
 "REDFISH_MESSAGE_ARGS": "TestArg"}}'

Severity - Informational, Debug, Notice, Warning, Error, Critical, Alert and Emergency

Tested fields: Verified on qemu.