### PR TITLE
RDE: Add rde operations support.

### DIFF
--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -207,7 +207,7 @@ inline void getCpuDataByInterface(
                 }
                 else
                 {
-                    messages::propertyNotUpdated(asyncResp->res,"PPIN");
+                    messages::propertyNotUpdated(asyncResp->res, "PPIN");
                 }
             }
             else if (property.first == "Microcode")
@@ -446,7 +446,7 @@ inline void getCpuAssetData(std::shared_ptr<bmcweb::AsyncResp> asyncResp,
         }
         else
         {
-            messages::propertyNotUpdated(asyncResp->res,"SerialNumber");
+            messages::propertyNotUpdated(asyncResp->res, "SerialNumber");
         }
 
         if ((model != nullptr) && !model->empty())
@@ -477,7 +477,7 @@ inline void getCpuAssetData(std::shared_ptr<bmcweb::AsyncResp> asyncResp,
         }
         else
         {
-            messages::propertyNotUpdated(asyncResp->res,"PartNumber");
+            messages::propertyNotUpdated(asyncResp->res, "PartNumber");
         }
 
         if (sparePartNumber != nullptr && !sparePartNumber->empty())
@@ -1322,7 +1322,6 @@ inline void requestRoutesProcessorCollection(App& app)
         asyncResp->res.jsonValue["@odata.id"] =
             std::format("/redfish/v1/Systems/{}/Processors",
                         BMCWEB_REDFISH_SYSTEM_URI_NAME);
-
         collection_util::getCollectionMembers(
             asyncResp,
             boost::urls::format("/redfish/v1/Systems/{}/Processors",
@@ -1375,6 +1374,11 @@ inline void requestRoutesProcessor(App& app)
         asyncResp->res.jsonValue["@odata.id"] =
             boost::urls::format("/redfish/v1/Systems/{}/Processors/{}",
                                 BMCWEB_REDFISH_SYSTEM_URI_NAME, processorId);
+
+        asyncResp->res.jsonValue["OEM"]["AmdSocConfigurationToken"] = {
+            {"#Processor.AmdSocConfigurationToken",
+             {{"@odata.id", "/redfish/v1/Systems/" + systemName + "/Processors/" +
+                             processorId + "/oem/AMD/SocConfiguration"}}}};
 
         asyncResp->res.jsonValue["Actions"]["Oem"] = {
             {"#Processor.OobErrorInjectionMode",

--- a/redfish-core/lib/rde.hpp
+++ b/redfish-core/lib/rde.hpp
@@ -7,6 +7,7 @@
 
 #include <boost/beast/http/status.hpp>
 #include <nlohmann/json.hpp>
+#include <sdbusplus/unpack_properties.hpp>
 
 #include <filesystem>
 #include <format>
@@ -18,8 +19,36 @@
 namespace redfish
 {
 
-constexpr std::string_view redfishSystemsBase = "/redfish/v1/Systems";
-constexpr std::string_view oemAmdRDEUri = "/oem/amd/RDE";
+constexpr std::string_view rdeRoot = "/redfish/v1/Systems/system";
+constexpr std::string_view pldmService = "xyz.openbmc_project.PLDM";
+std::map<uint8_t, std::string> eidUUIDMap;
+
+std::vector<std::string> uuidMapP0;
+std::vector<std::string> uuidMapP1;
+
+using SchemaResourcesType =
+    std::map<std::string,
+             std::map<std::string, dbus::utility::DbusVariantType>>;
+using RDEVariantType = std::variant<std::vector<std::string>, std::string,
+                                    uint8_t, SchemaResourcesType>;
+using RDEPropertiesMap = std::vector<std::pair<std::string, RDEVariantType>>;
+using ObjectPath = sdbusplus::message::object_path;
+
+std::vector<struct Resource> resourceVect;
+std::map<std::string, std::string> nameUriNameMap = {
+    {"Processors.Processors", "Processors"}};
+
+struct Resource
+{
+    std::string rid;
+    std::string subUri;
+    uint8_t eid;
+    std::string uuid;
+    std::string schemaName;
+    std::string schemaVersion;
+    int64_t schemaClass;
+    std::string fullUri;
+};
 
 // GET handler
 inline void rdeGetHandler(App& app, const crow::Request& req,
@@ -52,269 +81,386 @@ inline void rdePatchHandler(App& app, const crow::Request& req,
     asyncResp->res.jsonValue["status"] = "success";
 }
 
-inline nlohmann::json loadRDESchemaMap()
+std::string updateDeviceID(const std::string& path, const std::string& deviceId)
 {
-    constexpr const char* rdeUriCachePath = "/var/lib/pldm/rde_uri_cache.json";
+    // Find the position of the second slash
+    size_t firstSlash = path.find('/');
+    size_t secondSlash = path.find('/', firstSlash + 1);
 
-    nlohmann::json schemaMap = nlohmann::json::object();
-
-    if (!std::filesystem::exists(rdeUriCachePath))
+    if (secondSlash == std::string::npos)
     {
-        BMCWEB_LOG_ERROR("RDE: Schema file not found: {}", rdeUriCachePath);
-        return schemaMap; // Return empty object
+        // Path has only one segment or is malformed
+        return path;
     }
 
-    std::ifstream file(rdeUriCachePath);
+    // Insert the string after the first segment
+    std::string modifiedPath = path;
+    modifiedPath.insert(secondSlash, "/" + deviceId);
+    return modifiedPath;
+}
+
+inline void updateDeviceName(std::string& inputUri)
+{
+    for (const auto& [key, val] : nameUriNameMap)
+    {
+        size_t pos = inputUri.find(key);
+        if (pos != std::string::npos)
+        {
+            inputUri.replace(pos, key.length(), val);
+            break;
+        }
+    }
+}
+
+inline void rdeHandler(const crow::Request& /*req*/,
+                       const std::shared_ptr<bmcweb::AsyncResp>& /*asyncResp*/)
+{
+    // TODO Implement rdeHandler
+}
+
+inline std::string getDeviceID(std::string uuid)
+{
+    if (std::find(uuidMapP0.begin(), uuidMapP0.end(), uuid) != uuidMapP0.end())
+    {
+        return "P0";
+    }
+    if (std::find(uuidMapP1.begin(), uuidMapP1.end(), uuid) != uuidMapP1.end())
+    {
+        return "P1";
+    }
+    return "";
+}
+
+inline void
+    getRDEResourceData(const crow::Request& req,
+                       const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                       const std::string& expDeviceID,
+                       const std::string& objectPath, bool isRDERoot)
+{
+    sdbusplus::asio::getAllProperties(*crow::connections::systemBus,
+                                      std::string(pldmService), objectPath,
+                                      "xyz.openbmc_project.RDE.Device",
+                                      [req, asyncResp, expDeviceID, isRDERoot](
+                                          const boost::system::error_code& ec,
+                                          const RDEPropertiesMap& properties) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR("DBUS response error: {}", ec.message());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        const std::string* uuid = nullptr;
+        const uint8_t* eid = nullptr;
+        SchemaResourcesType schemaResources;
+
+        const bool success = sdbusplus::unpackPropertiesNoThrow(
+            dbus_utils::UnpackErrorPrinter(), properties, "DeviceUUID", uuid,
+            "EID", eid, "SchemaResources", schemaResources);
+
+        if (!success)
+        {
+            BMCWEB_LOG_ERROR(
+                "getRDEResourceData: unpackPropertiesNoThrow  error");
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        if (uuid == nullptr)
+        {
+            BMCWEB_LOG_ERROR("getRDEResourceData: Failed to get DeviceUUID");
+            messages::propertyNotUpdated(asyncResp->res, "DeviceUUID");
+        }
+
+        if (eid == nullptr)
+        {
+            BMCWEB_LOG_ERROR("getRDEResourceData: Failed to get EID");
+            messages::propertyNotUpdated(asyncResp->res, "EID");
+        }
+
+        std::string deviceID = getDeviceID(*uuid);
+        if (expDeviceID != deviceID)
+        {
+            BMCWEB_LOG_DEBUG(
+                "getRDEResourceData: DeviceID not matched, expDeviceID: {} deviceID: {}",
+                expDeviceID, deviceID);
+            return;
+        }
+        nlohmann::json resourceArray = nlohmann::json::array();
+
+        for (const auto& [rid, valueMap] : schemaResources)
+        {
+            std::string fullUri;
+            struct Resource res;
+            res.rid = rid;
+
+            // get subURI
+            auto subUriIt = valueMap.find("subUri");
+            if (subUriIt != valueMap.end())
+            {
+                auto* subUri = std::get_if<std::string>(&subUriIt->second);
+                if (subUri)
+                {
+                    std::string uri = *subUri;
+                    updateDeviceName(uri);
+                    res.subUri = uri;
+                    if (!deviceID.empty())
+                    {
+                        uri = updateDeviceID(uri, deviceID);
+                    }
+                    else
+                    {
+                        BMCWEB_LOG_INFO(
+                            "deviceID is empty, going with default");
+                    }
+                    fullUri = std::string(rdeRoot) + uri;
+                }
+            }
+
+            nlohmann::json resourceEntry = {{"@odata.id", fullUri}};
+
+            res.fullUri = fullUri;
+            res.eid = *eid;
+            res.uuid = *uuid;
+
+            auto nameIt = valueMap.find("schemaName");
+            if (nameIt != valueMap.end())
+            {
+                const auto* name = std::get_if<std::string>(&nameIt->second);
+                resourceEntry["MajorSchemaName"] = *name;
+                res.schemaName = *name;
+            }
+            auto classItr = valueMap.find("schemaClass");
+            if (classItr != valueMap.end())
+            {
+                const auto* schemaClass =
+                    std::get_if<int64_t>(&classItr->second);
+                resourceEntry["SchemaClass"] = *schemaClass;
+                res.schemaClass = *schemaClass;
+            }
+            auto verIt = valueMap.find("schemaVersion");
+            if (verIt != valueMap.end())
+            {
+                const auto* schemaVersion =
+                    std::get_if<std::string>(&verIt->second);
+                resourceEntry["MajorSchemaVersion"] = *schemaVersion;
+                res.schemaVersion = *schemaVersion;
+            }
+            resourceArray.push_back(resourceEntry);
+            resourceVect.push_back(res);
+        }
+
+        if (isRDERoot)
+        {
+            asyncResp->res.jsonValue["Resources"] = resourceArray;
+        }
+        else
+        {
+            rdeHandler(req, asyncResp);
+        }
+    });
+}
+
+inline bool loadRDEDeviceMetadata()
+{
+    constexpr const char* rdeDeviceMetadataFile =
+        "/etc/pldm/rde_device_metadata.json";
+
+    nlohmann::json jsonData = nlohmann::json::object();
+
+    if (!std::filesystem::exists(rdeDeviceMetadataFile))
+    {
+        BMCWEB_LOG_ERROR("RDE: Device metadata file not found: {}",
+                         rdeDeviceMetadataFile);
+        return false;
+    }
+
+    std::ifstream file(rdeDeviceMetadataFile);
     if (!file.is_open())
     {
-        BMCWEB_LOG_ERROR("RDE: Failed to open schema file: {}",
-                         rdeUriCachePath);
-        return schemaMap; // Return empty object
+        BMCWEB_LOG_ERROR("RDE: Failed to open device metadata file: {}",
+                         rdeDeviceMetadataFile);
+        return false;
     }
 
     try
     {
         if (file.peek() == std::ifstream::traits_type::eof())
         {
-            BMCWEB_LOG_ERROR("RDE: Schema file is empty: {}", rdeUriCachePath);
-            return schemaMap; // Return empty object
+            BMCWEB_LOG_ERROR("RDE: Device metadata file is empty: {}",
+                             rdeDeviceMetadataFile);
+            return false;
         }
 
-        file >> schemaMap;
+        file >> jsonData;
 
-        if (!schemaMap.is_object())
+        if (!jsonData.is_object())
         {
             BMCWEB_LOG_ERROR(
-                "RDE: Schema file does not contain a valid JSON object.");
-            return schemaMap; // Return empty object
+                "RDE: Device metadata file does not contain a valid JSON objects.");
+            return false;
+        }
+
+        const std::string deviceKey = "Processors";
+        if (!jsonData.contains(deviceKey) || !jsonData[deviceKey].is_object())
+        {
+            BMCWEB_LOG_ERROR("RDE: Missing or invalid '{}' section in metadata",
+                             deviceKey);
+            return false;
+        }
+
+        const auto& processors = jsonData[deviceKey];
+        std::vector<std::string> processorKeys = {"P0", "P1"};
+
+        for (const auto& procKey : processorKeys)
+        {
+            if (!processors.contains(procKey))
+            {
+                BMCWEB_LOG_ERROR("RDE: Missing processor key '{}'", procKey);
+                continue;
+            }
+
+            const auto& proc = processors.at(procKey);
+            if (!proc.contains("UUIDs") || !proc["UUIDs"].is_array())
+            {
+                BMCWEB_LOG_ERROR("RDE: Missing or invalid 'UUIDs' for '{}'",
+                                 procKey);
+                continue;
+            }
+
+            for (const auto& uuid : proc["UUIDs"])
+            {
+                if (!uuid.is_string())
+                {
+                    BMCWEB_LOG_ERROR("RDE: Invalid UUID format in '{}'",
+                                     procKey);
+                    continue;
+                }
+
+                const std::string uuidStr = uuid.get<std::string>();
+                if (procKey == "P0")
+                {
+                    uuidMapP0.push_back(uuidStr);
+                }
+                else if (procKey == "P1")
+                {
+                    uuidMapP1.push_back(uuidStr);
+                }
+            }
         }
     }
     catch (const nlohmann::json::parse_error& e)
     {
         BMCWEB_LOG_ERROR("RDE: JSON parse error: {}", e.what());
-        return schemaMap; // Return empty object
+        return false;
     }
     catch (const std::exception& e)
     {
-        BMCWEB_LOG_ERROR("RDE: Unexpected error while reading schema: {}",
-                         e.what());
-        return schemaMap; // Return empty object
+        BMCWEB_LOG_ERROR(
+            "RDE: Unexpected error while reading device metadata file: {}",
+            e.what());
+        return false;
     }
-
-    return schemaMap;
+    return true;
 }
 
-inline void handleRDE(crow::App& app, const crow::Request& req,
-                      const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                      const std::string& systemName,
-                      const std::string& resourceName,
-                      const std::string& processorId,
-                      const std::string& schemaPath)
+inline void reset()
 {
-    BMCWEB_LOG_DEBUG("RDE Request Handling[{} {} {} {}]", systemName,
-                     resourceName, processorId, schemaPath);
+    eidUUIDMap.clear();
+    resourceVect.clear();
+}
+
+inline void
+    getProcRdeDevices(const crow::Request& req,
+                      const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                      const std::string& deviceId, bool isRDERoot)
+{
+    reset();
+    constexpr std::array<std::string_view, 1> interfaces = {
+        "xyz.openbmc_project.RDE.Device"};
+    dbus::utility::getSubTreePaths(
+        "/", 0, interfaces,
+        [req, asyncResp, deviceId,
+         isRDERoot](const boost::system::error_code& ec,
+                    const dbus::utility::MapperGetSubTreePathsResponse&
+                        objPaths) mutable {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR(
+                "getProcRdeDevices : getSubTreePaths DBUS error: {}", ec);
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        for (const std::string& path : objPaths)
+        {
+            sdbusplus::message::object_path objPath(path);
+            std::string pathName = objPath.filename();
+            if (pathName.empty())
+            {
+                BMCWEB_LOG_ERROR("Failed to find '/' in {}", path);
+                continue;
+            }
+            BMCWEB_LOG_DEBUG("Found device with ObjectPath {}", path);
+            getRDEResourceData(req, asyncResp, deviceId, path, isRDERoot);
+        }
+    });
+}
+
+inline void handleProcRDE(crow::App& app, const crow::Request& req,
+                          const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                          const std::string& systemName,
+                          const std::string& deviceId,
+                          const std::string& schemaPath)
+{
+    BMCWEB_LOG_DEBUG("RDE Request Handling[{} {} {}]", systemName, deviceId,
+                     schemaPath);
 
     if (!redfish::setUpRedfishRoute(app, req, asyncResp))
     {
         return;
     }
-    std::string subUri = std::format("{}/{}{}/{}", resourceName, processorId,
-                                     oemAmdRDEUri, schemaPath);
-
-    nlohmann::json schemaMap = loadRDESchemaMap();
-    if (!schemaMap.contains("Resources") || !schemaMap["Resources"].is_object())
-    {
-        BMCWEB_LOG_ERROR("Invalid or missing 'Resources' in schemaMap");
-        asyncResp->res.result(boost::beast::http::status::not_acceptable);
-        asyncResp->res.jsonValue = {{"error", "Invalid or missing 'Resources"},
-                                    {"status", "failed"}};
-        return;
-    }
-
-    std::string expectedSubUri;
-
-    for (const auto& [resourceId, schema] : schemaMap["Resources"].items())
-    {
-        std::string tmpResourceName;
-        std::string tmpSubUri;
-        std::vector<std::string> expectedSubUris;
-
-        if (schema.contains("ProposedContainingResourceName") &&
-            schema["ProposedContainingResourceName"].is_string())
-        {
-            tmpResourceName =
-                schema["ProposedContainingResourceName"].get<std::string>();
-        }
-        if (schema.contains("SubURI") && schema["SubURI"].is_string())
-        {
-            tmpSubUri = schema["SubURI"].get<std::string>();
-            if (!tmpSubUri.empty())
-            {
-                expectedSubUris.push_back(std::format(
-                    "{}/{}/{}", tmpResourceName, processorId, tmpSubUri));
-            }
-        }
-        if (schema.contains("OEMExtensions") &&
-            schema["OEMExtensions"].is_array())
-        {
-            for (const auto& value : schema["OEMExtensions"])
-            {
-                if (value.is_string())
-                {
-                    const std::string& oemValue = value.get<std::string>();
-                    expectedSubUris.push_back(std::format(
-                        "{}/{}/{}", tmpResourceName, processorId, oemValue));
-                }
-            }
-        }
-        auto it = std::find(expectedSubUris.begin(), expectedSubUris.end(),
-                            subUri);
-        if (it != expectedSubUris.end())
-        {
-            expectedSubUri = *it;
-        }
-        if (!expectedSubUri.empty())
-        {
-            try
-            {
-                std::string majorSchemaName = "Unknown";
-                std::string majorSchemaVersion = "0_0_0";
-                if (schema.contains("MajorSchemaName") &&
-                    schema["MajorSchemaName"].is_string())
-                {
-                    majorSchemaName =
-                        schema["MajorSchemaName"].get<std::string>();
-                }
-                if (schema.contains("MajorSchemaVersion") &&
-                    schema["MajorSchemaVersion"].is_string())
-                {
-                    majorSchemaVersion =
-                        schema["MajorSchemaVersion"].get<std::string>();
-                }
-
-                asyncResp->res.jsonValue["@odata.type"] = "#RDE.v1_0_0.RDERoot";
-                std::string fullPath = std::format("{}/{}", redfishSystemsBase,
-                                                   subUri);
-                asyncResp->res.jsonValue["@odata.id"] = fullPath;
-                std::string odataType = "#" + majorSchemaName + ".v" +
-                                        majorSchemaVersion + "." +
-                                        majorSchemaName;
-                asyncResp->res.jsonValue["@odata.type"] = odataType;
-                asyncResp->res.jsonValue["ResourceID"] = resourceId;
-            }
-            catch (const std::exception& e)
-            {
-                BMCWEB_LOG_ERROR(
-                    "RDE: Error populating response from schema: {}", e.what());
-                asyncResp->res.result(
-                    boost::beast::http::status::internal_server_error);
-                asyncResp->res.jsonValue = {
-                    {"error", "Failed to populate response"}};
-                return;
-            }
-
-            // Handle HTTP methods
-            if (req.method() == boost::beast::http::verb::get)
-            {
-                rdeGetHandler(app, req, asyncResp);
-            }
-            else if (req.method() == boost::beast::http::verb::patch)
-            {
-                rdePatchHandler(app, req, asyncResp);
-            }
-            else
-            {
-                asyncResp->res.result(
-                    boost::beast::http::status::method_not_allowed);
-                asyncResp->res.jsonValue = {
-                    {"error", "Unsupported HTTP method"}};
-            }
-            return;
-        }
-    }
-    // No matching suburi found
-    BMCWEB_LOG_ERROR("RDE: No matching suburi found for input subUri: {}",
-                     subUri);
-    asyncResp->res.result(boost::beast::http::status::bad_request);
-    asyncResp->res.jsonValue = {
-        {"error", "Invalid subUri"}, {"subUri", subUri}, {"status", "failed"}};
-    return;
+    // TODO implement handleProcRDE process
 }
 
-inline void handleRDERoot([[maybe_unused]] crow::App& app,
-                          [[maybe_unused]] const crow::Request& req,
-                          const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                          const std::string& systemName)
+inline void handleProcessorRoot(
+    [[maybe_unused]] crow::App& app, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    [[maybe_unused]] const std::string& systemName, const std::string& deviceId)
 {
-    std::string baseUri = std::format("{}/{}", redfishSystemsBase, systemName);
-    asyncResp->res.jsonValue["@odata.type"] = "#RDE.v1_0_0.RDERoot";
-    asyncResp->res.jsonValue["@odata.id"] = baseUri;
+    asyncResp->res.jsonValue["@odata.type"] = "#RDE.v1_0_0.ProcessorRoot";
+    asyncResp->res.jsonValue["@odata.id"] = std::string(req.url().buffer());
     asyncResp->res.jsonValue["Name"] = "Redfish Dynamic Extensions";
 
-    // Load schema map
-    nlohmann::json schemaMap = loadRDESchemaMap();
-
-    if (!schemaMap.contains("Resources") || !schemaMap["Resources"].is_object())
+    if (!loadRDEDeviceMetadata())
     {
-        BMCWEB_LOG_ERROR("Invalid or missing 'Resources' in schemaMap");
+        BMCWEB_LOG_ERROR("Invalid or missing device identifiers in metadata");
         asyncResp->res.result(boost::beast::http::status::not_acceptable);
-        asyncResp->res.jsonValue = {{"error", "Invalid or missing 'Resources"},
-                                    {"status", "failed"}};
+        asyncResp->res.jsonValue = {
+            {"error", "Invalid or missing device identifier"},
+            {"status", "failed"}};
         return;
     }
 
-    nlohmann::json resourceArray = nlohmann::json::array();
-
-    for (const auto& [resourceId, schema] : schemaMap["Resources"].items())
-    {
-        try
-        {
-            if (!schema.is_object() || !schema.contains("SubURI") ||
-                !schema["SubURI"].is_string() ||
-                !schema.contains("ProposedContainingResourceName") ||
-                !schema["ProposedContainingResourceName"].is_string())
-            {
-                continue;
-            }
-
-            const std::string subUri = schema["SubURI"].get<std::string>();
-            const std::string resourceName =
-                schema["ProposedContainingResourceName"].get<std::string>();
-
-            std::string fullUri = std::format("{}/{}/{}/{}", baseUri,
-                                              resourceName, "<id>", subUri);
-
-            nlohmann::json resourceEntry = {{"@odata.id", fullUri}};
-            // Optionally include Actions if present
-            if (schema.contains("Actions") && schema["Actions"].is_array())
-            {
-                resourceEntry["Actions"] = schema["Actions"];
-            }
-            resourceArray.push_back(resourceEntry);
-        }
-        catch (const std::exception& e)
-        {
-            BMCWEB_LOG_ERROR("RDE: Exception processing resource {}: {}",
-                             resourceId, e.what());
-            continue;
-        }
-    }
-    asyncResp->res.jsonValue["Resources"] = resourceArray;
+    getProcRdeDevices(req, asyncResp, deviceId, true);
 }
 
 inline void requestRoutesRDEService(crow::App& app)
 {
-    BMCWEB_ROUTE(app,
-                 "/redfish/v1/Systems/<str>/<str>/<str>/oem/amd/RDE/<path>")
-        .privileges(redfish::privileges::privilegeSetConfigureManager)
+    BMCWEB_ROUTE(
+        app,
+        "/redfish/v1/Systems/<str>/Processors/<str>/oem/AMD/SocConfiguration/<path>")
+        .privileges(redfish::privileges::patchProcessor)
         .methods(boost::beast::http::verb::head, boost::beast::http::verb::get,
                  boost::beast::http::verb::patch)(
-            std::bind_front(handleRDE, std::ref(app)));
+            std::bind_front(handleProcRDE, std::ref(app)));
 
-    BMCWEB_ROUTE(app, "/redfish/v1/Systems/<str>/oem/amd/RDE")
-        .privileges(redfish::privileges::privilegeSetConfigureManager)
+    BMCWEB_ROUTE(
+        app,
+        "/redfish/v1/Systems/<str>/Processors/<str>/oem/AMD/SocConfiguration")
+        .privileges(redfish::privileges::getProcessor)
         .methods(boost::beast::http::verb::get)(
-            std::bind_front(handleRDERoot, std::ref(app)));
+            std::bind_front(handleProcessorRoot, std::ref(app)));
 }
 
 } // namespace redfish

--- a/redfish-core/lib/rde.hpp
+++ b/redfish-core/lib/rde.hpp
@@ -58,8 +58,77 @@ struct Resource
 
 std::string handleDeferredBindings(const std::string& bejJsonInput)
 {
-    // TDDO implement handleDeferredBindings
-    return bejJsonInput;
+    // Parse resource_registry.txt into uriMap
+    std::unordered_map<int, std::string> uriMap;
+
+    for (const auto& it : resourceVect)
+    {
+        int resourceId = std::stoi(it.rid);
+        uriMap[resourceId] = it.fullUri;
+    }
+
+    std::string bejJson = bejJsonInput;
+
+    std::regex bareObjectRegex("\\{\\s*\"%L(\\d+)\"\\s*\\}");
+    std::ostringstream oss1;
+    std::sregex_iterator begin1(bejJson.begin(), bejJson.end(),
+                                bareObjectRegex),
+        end1;
+    size_t lastPos1 = 0;
+
+    for (auto it = begin1; it != end1; ++it)
+    {
+        oss1 << bejJson.substr(
+            lastPos1,
+            static_cast<size_t>(static_cast<std::ptrdiff_t>(it->position()) -
+                                static_cast<std::ptrdiff_t>(lastPos1)));
+
+        int id = std::stoi((*it)[1]);
+        auto uriIt = uriMap.find(id);
+        if (uriIt != uriMap.end())
+        {
+            oss1 << R"({"@odata.id":")" << uriIt->second << R"("})";
+        }
+        else
+        {
+            oss1 << it->str(); // leave unchanged
+        }
+        lastPos1 = static_cast<size_t>(it->position() + it->length());
+    }
+    oss1 << bejJson.substr(lastPos1);
+    bejJson = oss1.str();
+
+    std::regex lPattern(R"(%L(\d+))");
+    std::ostringstream oss2;
+    std::sregex_iterator begin2(bejJson.begin(), bejJson.end(), lPattern), end2;
+    size_t lastPos2 = 0;
+
+    for (auto it = begin2; it != end2; ++it)
+    {
+        oss2 << bejJson.substr(
+            lastPos2,
+            static_cast<size_t>(static_cast<std::ptrdiff_t>(it->position()) -
+                                static_cast<std::ptrdiff_t>(lastPos2)));
+
+        int id = std::stoi((*it)[1]);
+        auto uriIt = uriMap.find(id);
+        if (uriIt != uriMap.end())
+        {
+            oss2 << uriIt->second;
+        }
+        else
+        {
+            oss2 << it->str(); // leave unchanged
+        }
+        lastPos2 = static_cast<size_t>(it->position() + it->length());
+    }
+    oss2 << bejJson.substr(lastPos2);
+    bejJson = oss2.str();
+
+    bejJson = std::regex_replace(bejJson, std::regex(R"(%I(\d+))"), "$1");
+    BMCWEB_LOG_ERROR("BEJ JSON String Output: {}", bejJson);
+
+    return bejJson;
 }
 
 inline bool rdeHandleCreateTask(const boost::system::error_code& ec2,

--- a/redfish-core/src/redfish.cpp
+++ b/redfish-core/src/redfish.cpp
@@ -241,11 +241,7 @@ RedfishService::RedfishService(App& app)
     requestRoutesMetricReport(app);
     requestRoutesTriggerCollection(app);
     requestRoutesTrigger(app);
-
-    if constexpr (BMCWEB_REDFISH_RDE)
-    {
-        requestRoutesRDEService(app);
-    }
+    requestRoutesRDEService(app);
 
     // Note, this must be the last route registered
     requestRoutesRedfish(app);


### PR DESCRIPTION
RDE: Add rde operations support.

Added GET  and PATCH operations on RDE resource URIs
handleProcessorRoot: To display all processor RDE URIs
handleProcRDE: Support GET operations on resources
handleDeferredBindings: Formats the deferred bindings

Commands tested:
'''
// Updated the below to display "oem/AMD/SocConfiguration" 
curl -s -k -u root:0penBmc -H "Content-type: application/json"   -X GET https://<BMC_IP>/redfish/v1/Systems/system/Processors/<ProcessorId>

curl -s -k -u root:0penBmc -H "Content-type: application/json"   -X GET https://<BMC_IP>/redfish/v1/Systems/system/Processors/<ProcessorID>/oem/AMD/SocConfiguration
curl -s -k -u root:0penBmc -H "Content-type: application/json"   -X GET https://<BMC_IP>/redfish/v1/Systems/system/Processors/<ProcessorID>/oem/AMD/SocConfiguration/<path>
curl -s -k -u root:0penBmc -H "Content-type: application/json"   -X PATCH https://<BMC_IP>/redfish/v1/Systems/system/Processors/<ProcessorID>/oem/AMD/SocConfiguration/<path> -d "{xxxx}"

'''

Signed-off-by: Raja Sekhar Reddy Gade <rajagade@amd.com>