### PR TITLE
Enable support for event log updates and deletions

### DIFF
--- a/redfish-core/src/redfish.cpp
+++ b/redfish-core/src/redfish.cpp
@@ -135,7 +135,7 @@ RedfishService::RedfishService(App& app)
         requestRoutesFaultLogDumpClear(app);
     }
 
-    if constexpr (!BMCWEB_REDFISH_DBUS_LOG)
+    if constexpr (BMCWEB_REDFISH_DBUS_LOG)
     {
         requestRoutesJournalEventLogEntryCollection(app);
         requestRoutesJournalEventLogEntry(app);
@@ -188,7 +188,7 @@ RedfishService::RedfishService(App& app)
         requestNBDVirtualMediaRoutes(app);
     }
 
-    if constexpr (BMCWEB_REDFISH_DBUS_LOG)
+    if constexpr (!BMCWEB_REDFISH_DBUS_LOG)
     {
         requestRoutesDBusLogServiceActionsClear(app);
         requestRoutesDBusEventLogEntryCollection(app);


### PR DESCRIPTION
Previously, updating the event log status and deleting events were
disabled by default. This commit enables both functionalities.

Tested:
- Verified that event logs can now be updated.
- Verified that event logs can be deleted successfully.