### PR TITLE
bmcweb: remove Capacity & revisionCode conversion

### DIFF
--- a/redfish-core/lib/memory.hpp
+++ b/redfish-core/lib/memory.hpp
@@ -411,7 +411,7 @@ inline void
     const std::string* partNumber = nullptr;
     const std::string* serialNumber = nullptr;
     const std::string* manufacturer = nullptr;
-    const uint16_t* revisionCode = nullptr;
+    const std::string* revisionCode = nullptr;
     const bool* present = nullptr;
     const uint16_t* memoryTotalWidth = nullptr;
     const std::string* ecc = nullptr;
@@ -457,8 +457,7 @@ inline void
 
     if (memorySizeInKB != nullptr)
     {
-        asyncResp->res.jsonValue[jsonPtr]["CapacityMiB"] =
-            (*memorySizeInKB >> 10);
+        asyncResp->res.jsonValue[jsonPtr]["CapacityMiB"] = *memorySizeInKB ;
     }
 
     if (partNumber != nullptr && !partNumber->empty() &&
@@ -488,8 +487,7 @@ inline void
 
     if (revisionCode != nullptr)
     {
-        asyncResp->res.jsonValue[jsonPtr]["FirmwareRevision"] =
-            std::to_string(*revisionCode);
+        asyncResp->res.jsonValue[jsonPtr]["FirmwareRevision"] = *revisionCode;
     }
 
     if (present != nullptr && !*present)
@@ -875,7 +873,7 @@ inline void
         }
         else
         {
-            BMCWEB_LOG_ERROR("Dimm -Not supported type received from BIOS");
+            BMCWEB_LOG_ERROR("Dimm -Not supported type received from BIOS key = {} and value = {}", key, value);
         }
     }
 
@@ -885,7 +883,7 @@ inline void
         [asyncResp](const boost::system::error_code ec) {
         if (ec)
         {
-            BMCWEB_LOG_DEBUG("DIMM - POST D-Bus responses error: {}", ec);
+            BMCWEB_LOG_ERROR("DIMM - POST D-Bus responses error: {}", ec);
             messages::internalError(asyncResp->res);
             return;
         }


### PR DESCRIPTION
-CapacityMiB value receive from bios is in Mib, no conversion needed -revisionCode keep as is std::string

Tested fields: Verified on Congo