### PR TITLE
Add journal logging to Redfish event POST API

### DIFF
--- a/redfish-core/src/redfish.cpp
+++ b/redfish-core/src/redfish.cpp
@@ -112,7 +112,6 @@ RedfishService::RedfishService(App& app)
     requestRoutesPostCodesClear(app);
     requestRoutesPostCodesEntry(app);
     requestRoutesPostCodesEntryCollection(app);
-    requestRoutesEventLogEntriesPost(app);
 
     if constexpr (BMCWEB_REDFISH_DUMP_LOG)
     {
@@ -140,6 +139,7 @@ RedfishService::RedfishService(App& app)
         requestRoutesJournalEventLogEntryCollection(app);
         requestRoutesJournalEventLogEntry(app);
         requestRoutesJournalEventLogClear(app);
+        requestRoutesJournalEventLogEntryPost(app);
     }
 
     requestRoutesBMCLogServiceCollection(app);
@@ -193,6 +193,7 @@ RedfishService::RedfishService(App& app)
         requestRoutesDBusLogServiceActionsClear(app);
         requestRoutesDBusEventLogEntryCollection(app);
         requestRoutesDBusEventLogEntry(app);
+        requestRoutesDBusEventLogEntryPost(app);
         requestRoutesDBusEventLogEntryDownload(app);
     }
 


### PR DESCRIPTION
This change enhances the Redfish Event Log Entry POST API by adding support for logging events to the system journal using sd_journal_send().

Tested on congo platform:

Verified that Redfish events are correctly logged and visible on the WebUI.

'''
Tested command:
curl -s -k -u root:0penBmc -H "Content-type: application/json" -X POST https://<BMC_IP>/redfish/v1/Systems/system/LogServices/EventLog -d '{"Message": "Test new log entry message", "Severity": 2, "AdditionalData": {"REDFISH_MESSAGE_ID": "OpenBMC.0.1.ServiceFailure", "REDFISH_MESSAGE_ARGS": "Test3Service"}}' '''