### PR TITLE
Enhance IP filtering to allow multiple USB vNIC IPs

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -1685,10 +1685,12 @@ inline bool isAllowedIP(const crow::Request& req)
 {
     std::string ipStr = req.ipAddress.to_string();
     // IP of the USB vNIC
-    constexpr std::string_view allowedIp = "192.168.31.2";
+    constexpr std::string_view allowedIp1 = "192.168.31.1";
+    constexpr std::string_view allowedIp2 = "192.168.31.2";
 
     // Check if the IP string contains the allowed IP
-    if (ipStr.find(allowedIp) == std::string::npos)
+    if (ipStr.find(allowedIp1) == std::string::npos &&
+        ipStr.find(allowedIp2) == std::string::npos)
     {
         BMCWEB_LOG_ERROR("Unmatched IP: {} ", ipStr);
         return false;
@@ -1698,7 +1700,6 @@ inline bool isAllowedIP(const crow::Request& req)
 
 inline void requestRoutesJournalEventLogEntryPost(App& app)
 {
-    BMCWEB_LOG_ERROR("Entred: requestRoutesEventLogEntriesPost");
     BMCWEB_ROUTE(app, "/redfish/v1/Systems/<str>/LogServices/EventLog")
         .privileges(redfish::privileges::postLogEntry)
         .methods(boost::beast::http::verb::post)(
@@ -1752,7 +1753,6 @@ inline void requestRoutesJournalEventLogEntryPost(App& app)
 
 inline void requestRoutesDBusEventLogEntryPost(App& app)
 {
-    BMCWEB_LOG_ERROR("Entred: requestRoutesEventLogEntriesPost");
     BMCWEB_ROUTE(app, "/redfish/v1/Systems/<str>/LogServices/EventLog")
         .privileges(redfish::privileges::postLogEntry)
         .methods(boost::beast::http::verb::post)(


### PR DESCRIPTION
Updated `isAllowedIP()` to support both 192.168.31.1 and 192.168.31.2 as valid USB vNIC IP addresses.

Clean up: Removed redundant error log

Tests:
Redfish event generation from USB vNIC ip "192.168.31.2" is success.
Able to view the redfish event in bmcweb.