### PR TITLE
 Add a check for hostNumber

### DIFF
--- a/redfish-core/lib/update_service.hpp
+++ b/redfish-core/lib/update_service.hpp
@@ -488,7 +488,7 @@ inline void monitorForSoftwareAvailable(
         }
     }
 
-    if (hostNumber > 2)
+    if (hostNumber == 0 || hostNumber > 2)
     {
         messages::actionParameterNotSupported(
             asyncResp->res, std::to_string(hostNumber), "HostNumber");
@@ -1407,7 +1407,7 @@ inline void handleUpdateServiceFirmwareInventoryGet(
         }
     }
 
-    if (hostNumber > 2)
+    if (hostNumber == 0 || hostNumber > 2)
     {
         messages::actionParameterNotSupported(
             asyncResp->res, std::to_string(hostNumber), "HostNumber");


### PR DESCRIPTION
Check whether the parameter hostNumber is 0 on a 2*1P enabled platform.
0 is not a valid parameter value for the resource bios_active, so
return error instead of a valid respone.

Tested:
Verified on a 2*1P enabled platform

Signed-off-by: spargaon <Shirish.Pargaonkar@amd.com>