### PR TITLE
rde: enable UNIX local socket

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -42,6 +42,7 @@ feature_options = [
     'tests',
     'vm-websocket',
     'xtoken-auth',
+    'local-socket',
 ]
 
 string_options = [
@@ -132,6 +133,26 @@ if https_port > 0
                 'BMCWEB_PORT': https_port,
                 'HTTP_LEVEL_ALLOWED': 'https',
                 'HTTP_AUTH_LEVEL': 'auth',
+                'HTTP_BIND': '',
+            },
+        ),
+    )
+endif
+
+local_socket_enabled = get_option('local-socket')
+local_socket_path = get_option('local_socket_path')
+
+if local_socket_enabled.allowed()
+    configure_file(
+        input: 'bmcweb.socket.in',
+        output: 'bmcweb.local.socket',
+        install_dir: systemd_system_unit_dir,
+        install: true,
+        configuration: configuration_data(
+            {
+                'BMCWEB_PORT': local_socket_path,
+                'HTTP_LEVEL_ALLOWED': 'http',
+                'HTTP_AUTH_LEVEL': 'noauth',
                 'HTTP_BIND': '',
             },
         ),

--- a/http/app.hpp
+++ b/http/app.hpp
@@ -7,6 +7,7 @@
 #include "http_request.hpp"
 #include "http_server.hpp"
 #include "io_context_singleton.hpp"
+#include "local_socket_server.hpp"
 #include "logging.hpp"
 #include "routing.hpp"
 #include "routing/dynamicrule.hpp"
@@ -16,6 +17,7 @@
 #include <systemd/sd-daemon.h>
 
 #include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/local/stream_protocol.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -38,6 +40,9 @@ class App
   public:
     using raw_socket_t = boost::asio::ip::tcp::socket;
     using server_type = Server<App, raw_socket_t>;
+
+    using local_socket_t = boost::asio::local::stream_protocol::socket;
+    using local_server_type = LocalSocketServer<App, local_socket_t>;
 
     template <typename Adaptor>
     void handleUpgrade(const std::shared_ptr<Request>& req,
@@ -165,6 +170,20 @@ class App
 
         server.emplace(this, std::move(acceptors));
         server->run();
+        if constexpr (BMCWEB_LOCAL_SOCKET)
+        {
+            auto localAcceptor =
+                local_server_type::setupLocalSocket(getIoContext());
+            if (!localAcceptor)
+            {
+                BMCWEB_LOG_ERROR("Couldn't start local socket server");
+                return;
+            }
+
+            localServer.emplace(this, std::move(*localAcceptor),
+                                getIoContext());
+            localServer->run();
+        }
     }
 
     void debugPrint()
@@ -184,6 +203,7 @@ class App
     }
 
     std::optional<server_type> server;
+    std::optional<local_server_type> localServer;
 
     Router router;
 };

--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -21,6 +21,7 @@
 
 #include <boost/asio/error.hpp>
 #include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/local/stream_protocol.hpp>
 #include <boost/asio/ssl/stream.hpp>
 #include <boost/asio/ssl/stream_base.hpp>
 #include <boost/asio/ssl/verify_context.hpp>
@@ -501,9 +502,26 @@ class Connection :
 
     void readClientIp()
     {
-        boost::system::error_code ec;
+        if constexpr (std::is_same_v<Adaptor, boost::asio::ip::tcp::socket>)
+        {
+            readClientIpFromTcpSocket();
+        }
+        else
+        {
+            BMCWEB_LOG_DEBUG("Not tcp socket, skipping readClientIp");
+        }
+    }
 
-        boost::asio::ip::tcp::endpoint endpoint =
+    void disableAuth()
+    {
+        authenticationEnabled = false;
+    }
+
+  private:
+    void readClientIpFromTcpSocket()
+    {
+        boost::system::error_code ec;
+        auto endpoint =
             boost::beast::get_lowest_layer(adaptor).remote_endpoint(ec);
 
         if (ec)
@@ -517,12 +535,6 @@ class Connection :
         ip = endpoint.address();
     }
 
-    void disableAuth()
-    {
-        authenticationEnabled = false;
-    }
-
-  private:
     uint64_t getContentLengthLimit()
     {
         if constexpr (!BMCWEB_INSECURE_DISABLE_AUTH)

--- a/http/local_socket_server.hpp
+++ b/http/local_socket_server.hpp
@@ -1,0 +1,165 @@
+#pragma once
+#include "http_connection.hpp"
+#include "logging.hpp"
+
+#include <systemd/sd-daemon.h>
+
+#include <boost/asio/local/stream_protocol.hpp>
+#include <boost/asio/ssl/context.hpp>
+#include <boost/asio/ssl/stream.hpp>
+#include <boost/asio/steady_timer.hpp>
+
+#include <chrono>
+#include <ctime>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+
+namespace crow
+{
+
+template <typename Handler,
+          typename Adaptor = boost::asio::local::stream_protocol::socket>
+class LocalSocketServer
+{
+    using Acceptor = boost::asio::local::stream_protocol::acceptor;
+    using self_t = LocalSocketServer<Handler, Adaptor>;
+
+  public:
+    LocalSocketServer(Handler* handlerIn, Acceptor&& acceptorIn,
+                      boost::asio::io_context& ioContextIn) :
+        handler(handlerIn), localAcceptor(std::move(acceptorIn)),
+        ioContext(ioContextIn)
+    {}
+
+    void run()
+    {
+        BMCWEB_LOG_INFO("Local socket server is running");
+        doAccept();
+    }
+
+    void doAccept()
+    {
+        auto socket = std::make_unique<Adaptor>(ioContext);
+        Adaptor* socketPtr = socket.get();
+
+        localAcceptor.async_accept(
+            *socketPtr,
+            std::bind_front(&self_t::afterAccept, this, std::move(socket)));
+    }
+
+    void afterAccept(std::unique_ptr<Adaptor> socket,
+                     const boost::system::error_code& ec)
+    {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR("Failed to accept local socket connection {}", ec);
+            return;
+        }
+
+        BMCWEB_LOG_DEBUG("Accepted local socket connection");
+
+        // Create a dummy SSL context for local socket connections
+        // Local sockets don't need SSL, but the Connection class expects it
+        auto sslCtx = std::make_shared<boost::asio::ssl::context>(
+            boost::asio::ssl::context::tls_server);
+
+        // Create a dummy SSL stream that wraps the local socket
+        boost::asio::ssl::stream<Adaptor> sslStream(std::move(*socket),
+                                                    *sslCtx);
+
+        // Create a timer for the connection
+        boost::asio::steady_timer timer(ioContext);
+
+        // Create connection with admin privileges
+        using ConnectionType = Connection<Adaptor, Handler>;
+        auto connection = std::make_shared<ConnectionType>(
+            handler, HttpType::HTTP, std::move(timer), getCachedDateStr,
+            std::move(sslStream));
+
+        // Disable authentication for local socket connections
+        // This allows them to bypass all authentication checks
+        connection->disableAuth();
+
+        // Start the connection - it will detect that it's not SSL and proceed
+        // with HTTP
+        boost::asio::post(ioContext, [connection] { connection->start(); });
+
+        // Continue accepting new connections
+        doAccept();
+    }
+
+    static std::optional<Acceptor> setupLocalSocket(
+        boost::asio::io_context& ioContext)
+    {
+        using boost::asio::local::stream_protocol;
+        char** names = nullptr;
+        int listenFdCount = sd_listen_fds_with_names(0, &names);
+        BMCWEB_LOG_DEBUG("Got {} sockets to open", listenFdCount);
+
+        if (listenFdCount < 0)
+        {
+            BMCWEB_LOG_CRITICAL("Failed to read socket files");
+            return std::nullopt;
+        }
+        int socketIndex = 0;
+        for (char* name :
+             std::span<char*>(names, static_cast<size_t>(listenFdCount)))
+        {
+            if (name == nullptr)
+            {
+                continue;
+            }
+
+            int listenFd = socketIndex + SD_LISTEN_FDS_START;
+            if (sd_is_socket_unix(listenFd, SOCK_STREAM, 1, nullptr, 0) > 0)
+            {
+                BMCWEB_LOG_INFO("Starting webserver on local socket handle {}",
+                                listenFd);
+                return stream_protocol::acceptor(ioContext, stream_protocol(),
+                                                 listenFd);
+            }
+            socketIndex++;
+        }
+
+        constexpr const char* socketPath = "/tmp/run/local_access.sock";
+        BMCWEB_LOG_INFO("Starting webserver on local socket {}", socketPath);
+        stream_protocol::endpoint end(socketPath);
+        return stream_protocol::acceptor(ioContext, end);
+    }
+
+  private:
+    Handler* handler;
+    Acceptor localAcceptor;
+    boost::asio::io_context& ioContext;
+    std::string dateStr;
+
+    void updateDateStr()
+    {
+        time_t lastTimeT = time(nullptr);
+        tm myTm{};
+
+        gmtime_r(&lastTimeT, &myTm);
+
+        dateStr.resize(100);
+        size_t dateStrSz = strftime(dateStr.data(), dateStr.size() - 1,
+                                    "%a, %d %b %Y %H:%M:%S GMT", &myTm);
+        dateStr.resize(dateStrSz);
+    }
+
+    std::function<std::string()> getCachedDateStr = [this]() -> std::string {
+        static std::chrono::time_point<std::chrono::steady_clock>
+            lastDateUpdate = std::chrono::steady_clock::now();
+        if (std::chrono::steady_clock::now() - lastDateUpdate >=
+            std::chrono::seconds(10))
+        {
+            lastDateUpdate = std::chrono::steady_clock::now();
+            updateDateStr();
+        }
+        return this->dateStr;
+    };
+};
+
+} // namespace crow

--- a/http/routing/baserule.hpp
+++ b/http/routing/baserule.hpp
@@ -8,6 +8,7 @@
 #include "verb.hpp"
 
 #include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/local/stream_protocol.hpp>
 #include <boost/asio/ssl/stream.hpp>
 #include <boost/beast/http/status.hpp>
 
@@ -53,7 +54,22 @@ class BaseRule
     {
         asyncResp->res.result(boost::beast::http::status::not_found);
     }
+    virtual void handleUpgrade(
+        const Request& /*req*/,
+        const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+        boost::asio::local::stream_protocol::socket&& /*adaptor*/)
+    {
+        asyncResp->res.result(boost::beast::http::status::not_found);
+    }
 
+    virtual void handleUpgrade(
+        const Request& /*req*/,
+        const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+        boost::asio::ssl::stream<
+            boost::asio::local::stream_protocol::socket>&& /*adaptor*/)
+    {
+        asyncResp->res.result(boost::beast::http::status::not_found);
+    }
     virtual void handleUpgrade(
         const Request& /*req*/,
         const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,

--- a/http/routing/sserule.cpp
+++ b/http/routing/sserule.cpp
@@ -62,5 +62,23 @@ void SseSocketRule::handleUpgrade(
             std::move(adaptor), openHandler, closeHandler);
     myConnection->start(req);
 }
+void SseSocketRule::handleUpgrade(
+    const Request& /*req*/,
+    const std::shared_ptr<bmcweb::AsyncResp>& /*asyncResp*/,
+    boost::asio::local::stream_protocol::socket&& /*adaptor*/)
+{
+    // It used for resolving build error, local socket connections don't use
+    // upgrade
+}
+
+void SseSocketRule::handleUpgrade(
+    const Request& /*req*/,
+    const std::shared_ptr<bmcweb::AsyncResp>& /*asyncResp*/,
+    boost::asio::ssl::stream<
+        boost::asio::local::stream_protocol::socket>&& /*adaptor*/)
+{
+    // It used for resolving build error, local socket connections don't use
+    // upgrade
+}
 
 } // namespace crow

--- a/http/routing/sserule.hpp
+++ b/http/routing/sserule.hpp
@@ -38,6 +38,16 @@ class SseSocketRule : public BaseRule
                        const std::shared_ptr<bmcweb::AsyncResp>& /*asyncResp*/,
                        boost::asio::ssl::stream<boost::asio::ip::tcp::socket>&&
                            adaptor) override;
+    void handleUpgrade(
+        const Request& req,
+        const std::shared_ptr<bmcweb::AsyncResp>& /*asyncResp*/,
+        boost::asio::local::stream_protocol::socket&& adaptor) override;
+
+    void handleUpgrade(
+        const Request& req,
+        const std::shared_ptr<bmcweb::AsyncResp>& /*asyncResp*/,
+        boost::asio::ssl::stream<boost::asio::local::stream_protocol::socket>&&
+            adaptor) override;
 
     template <typename Func>
     self_t& onopen(Func f)

--- a/http/routing/websocketrule.cpp
+++ b/http/routing/websocketrule.cpp
@@ -43,4 +43,24 @@ void WebSocketRule::handleUpgrade(
             messageHandler, messageExHandler, closeHandler, errorHandler);
     myConnection->start(req);
 }
+
+void WebSocketRule::handleUpgrade(
+    const Request& /*req*/,
+    const std::shared_ptr<bmcweb::AsyncResp>& /*asyncResp*/,
+    boost::asio::local::stream_protocol::socket&& /*adaptor*/)
+{
+    // It used for resolving build error, local socket connections don't use
+    // upgrade
+}
+
+void WebSocketRule::handleUpgrade(
+    const Request& /*req*/,
+    const std::shared_ptr<bmcweb::AsyncResp>& /*asyncResp*/,
+    boost::asio::ssl::stream<
+        boost::asio::local::stream_protocol::socket>&& /*adaptor*/)
+{
+    // It used for resolving build error, local socket connections don't use
+    // upgrade
+}
+
 } // namespace crow

--- a/http/routing/websocketrule.hpp
+++ b/http/routing/websocketrule.hpp
@@ -9,6 +9,7 @@
 #include "websocket.hpp"
 
 #include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/local/stream_protocol.hpp>
 #include <boost/asio/ssl/stream.hpp>
 #include <boost/beast/http/status.hpp>
 
@@ -52,6 +53,17 @@ class WebSocketRule : public BaseRule
                        const std::shared_ptr<bmcweb::AsyncResp>& /*asyncResp*/,
                        boost::asio::ssl::stream<boost::asio::ip::tcp::socket>&&
                            adaptor) override;
+
+    void handleUpgrade(
+        const Request& req,
+        const std::shared_ptr<bmcweb::AsyncResp>& /*asyncResp*/,
+        boost::asio::local::stream_protocol::socket&& adaptor) override;
+
+    void handleUpgrade(
+        const Request& req,
+        const std::shared_ptr<bmcweb::AsyncResp>& /*asyncResp*/,
+        boost::asio::ssl::stream<boost::asio::local::stream_protocol::socket>&&
+            adaptor) override;
 
     template <typename Func>
     self_t& onopen(Func f)

--- a/meson.build
+++ b/meson.build
@@ -429,6 +429,7 @@ srcfiles_unittest = files(
     'test/http/http2_connection_test.cpp',
     'test/http/http_body_test.cpp',
     'test/http/http_connection_test.cpp',
+    'test/http/local_socket_server_test.cpp',
     'test/http/http_response_test.cpp',
     'test/http/mutual_tls.cpp',
     'test/http/mutual_tls_meta.cpp',

--- a/meson.options
+++ b/meson.options
@@ -472,6 +472,23 @@ option(
                     Set to 0 to disable the watchdog.''',
 )
 
+# BMCWEB_LOCAL_SOCKET
+option(
+    'local-socket',
+    type: 'feature',
+    value: 'enabled',
+    description: '''Enable local socket access for bmcweb. This allows
+                    communication through a Unix domain socket for local
+                    processes.''',
+)
+
+option(
+    'local_socket_path',
+    type: 'string',
+    value: '/tmp/run/local_bmcweb.sock',
+    description: 'Local socket path.',
+)
+
 # Insecure options. Every option that starts with a `insecure` flag should
 # not be enabled by default for any platform, unless the author fully comprehends
 # the implications of doing so.In general, enabling these options will cause security

--- a/redfish-core/lib/rde.hpp
+++ b/redfish-core/lib/rde.hpp
@@ -1240,12 +1240,13 @@ inline void requestRoutesRDEService(crow::App& app)
                    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                    const std::string& systemId, const std::string& deviceId,
                    const std::string& vendorPath) {
-        std::string baseUri = "/redfish/v1/Systems/" + systemId +
-                              "/NetworkAdapters/" + deviceId;
+                std::string baseUri = "/redfish/v1/Systems/" + systemId +
+                                      "/NetworkAdapters/" + deviceId;
 
-        handleRDEServicePath(app, req, asyncResp, systemId, deviceId,
-                             vendorPath, redfish::networkSchemaName, baseUri);
-    });
+                handleRDEServicePath(app, req, asyncResp, systemId, deviceId,
+                                     vendorPath, redfish::networkSchemaName,
+                                     baseUri);
+            });
 
     BMCWEB_ROUTE(app, "/redfish/v1/Systems/<str>/NetworkAdapters/<str>")
         .privileges(redfish::privileges::getProcessor)
@@ -1253,11 +1254,11 @@ inline void requestRoutesRDEService(crow::App& app)
             [&app](const crow::Request& req,
                    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                    const std::string& systemId, const std::string& deviceId) {
-        std::string baseUri = "/redfish/v1/Systems/" + systemId +
-                              "/NetworkAdapters/" + deviceId;
-        handleRDEServiceRoot(app, req, asyncResp, systemId, deviceId,
-                             redfish::networkSchemaName, baseUri);
-    });
+                std::string baseUri = "/redfish/v1/Systems/" + systemId +
+                                      "/NetworkAdapters/" + deviceId;
+                handleRDEServiceRoot(app, req, asyncResp, systemId, deviceId,
+                                     redfish::networkSchemaName, baseUri);
+            });
 }
 
 } // namespace redfish

--- a/redfish-core/lib/rde.hpp
+++ b/redfish-core/lib/rde.hpp
@@ -171,7 +171,14 @@ inline nlohmann::json handleDeferredBindings(const std::string& bejJsonInput,
     bejJson = std::regex_replace(bejJson, std::regex(R"(%I(\d+))"), "$1");
     BMCWEB_LOG_DEBUG("RDE: BEJ JSON String Output: {}", bejJson);
 
-    return nlohmann::json::parse(bejJson);
+    nlohmann::json jsonPayload;
+    if(!bejJson.empty())
+    {
+        jsonPayload = nlohmann::json::parse(bejJson);
+        return jsonPayload;
+    }
+    else
+        return jsonPayload;
 }
 /**
  * @brief Process the TaskUpdated signal for an RDE Operation Task.

--- a/test/http/local_socket_server_test.cpp
+++ b/test/http/local_socket_server_test.cpp
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright OpenBMC Authors
+#include "async_resp.hpp"
+#include "http/http_request.hpp"
+#include "http/local_socket_server.hpp"
+
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/local/stream_protocol.hpp>
+#include <boost/beast/core/flat_buffer.hpp>
+#include <boost/beast/http/message.hpp>
+#include <boost/beast/http/read.hpp>
+#include <boost/beast/http/string_body.hpp>
+#include <boost/beast/http/write.hpp>
+
+#include <memory>
+#include <thread>
+
+#include "gtest/gtest.h"
+
+namespace crow
+{
+
+// Enhanced mock handler for testing - captures request data
+struct MockHandler
+{
+    void handle(const std::shared_ptr<crow::Request>& req,
+                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+    {
+        handleCalled = true;
+
+        EXPECT_EQ(req->method(), boost::beast::http::verb::post);
+        EXPECT_EQ(req->target(), "/test/endpoint");
+        EXPECT_EQ(req->getHeaderValue(boost::beast::http::field::host),
+                  "localServer");
+        EXPECT_EQ(req->body(), R"({"test": "data", "value": 42})");
+
+        // Send a simple response
+        if (asyncResp)
+        {
+            asyncResp->res.result(boost::beast::http::status::ok);
+            asyncResp->res.jsonValue["message"] =
+                "Request received successfully";
+        }
+    }
+
+    template <typename Adaptor>
+    void handleUpgrade(const std::shared_ptr<crow::Request>& /*req*/,
+                       const std::shared_ptr<bmcweb::AsyncResp>& /*asyncResp*/,
+                       Adaptor&& /*adaptor*/)
+    {
+        // Local socket connections don't use upgrade
+        EXPECT_FALSE(true);
+    }
+
+    bool handleCalled = false;
+};
+
+TEST(local_socket_server, ReceiveDataFromLocalSocket)
+{
+    using Acceptor = boost::asio::local::stream_protocol::acceptor;
+    using Socket = boost::asio::local::stream_protocol::socket;
+    using Endpoint = boost::asio::local::stream_protocol::endpoint;
+    boost::asio::io_context io;
+
+    // Create a temporary socket file for testing
+    const std::string socketPath = "/tmp/test_local_socket.sock";
+    std::remove(socketPath.c_str()); // Clean up any existing socket file
+
+    // Create acceptor bound to the socket file
+    Endpoint endpoint(socketPath);
+    Acceptor acceptor(io, endpoint);
+    MockHandler handler;
+
+    LocalSocketServer<MockHandler> server(&handler, std::move(acceptor), io);
+
+    // Start the server in a separate thread
+    std::thread serverThread(
+        &server, &io {
+            server.run();
+            // Run the io_context to process async operations
+            io.run();
+        });
+
+    // Give the server time to start
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    // Create a client socket and connect
+    Socket clientSocket(io);
+    boost::system::error_code ec;
+    clientSocket.connect(endpoint, ec);
+
+    ASSERT_FALSE(ec) << "Failed to connect to local socket: " << ec.message();
+
+    // Prepare HTTP request data
+    boost::beast::http::request<boost::beast::http::string_body> req{
+        boost::beast::http::verb::post, "/test/endpoint", 11};
+    req.set(boost::beast::http::field::host, "localServer");
+    req.set(boost::beast::http::field::content_type, "application/json");
+    req.set(boost::beast::http::field::user_agent, "TestClient/1.0");
+    req.set(boost::beast::http::field::content_length, "32");
+    req.body() = R"({"test": "data", "value": 42})";
+    req.prepare_payload();
+
+    // Send the HTTP request
+    boost::beast::http::write(clientSocket, req, ec);
+    ASSERT_FALSE(ec) << "Failed to write HTTP request: " << ec.message();
+
+    // Wait for the handler to be called
+    auto start = std::chrono::steady_clock::now();
+    while (!handler.handleCalled &&
+           std::chrono::steady_clock::now() - start < std::chrono::seconds(5))
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    // Verify that the handler was called and data was captured correctly
+    EXPECT_TRUE(handler.handleCalled) << "Handler was not called";
+
+    // Give some time for the response to be sent
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    // Read and verify the HTTP response
+    boost::beast::flat_buffer buffer;
+    boost::beast::http::response<boost::beast::http::string_body> response;
+    boost::beast::http::read(clientSocket, buffer, response, ec);
+    ASSERT_FALSE(ec) << "Failed to read HTTP response: " << ec.message();
+
+    // Verify response status
+    EXPECT_EQ(response.result(), boost::beast::http::status::ok);
+    EXPECT_EQ(response.result_int(), 200);
+
+    // Verify response headers
+    EXPECT_EQ(response[boost::beast::http::field::content_type],
+              "application/json");
+
+    // Verify response body contains the expected JSON message
+    EXPECT_FALSE(response.body().empty());
+    EXPECT_TRUE(response.body().find("Request received successfully") !=
+                std::string::npos);
+    EXPECT_TRUE(response.body().find("\"message\"") != std::string::npos);
+
+    // Clean up
+    clientSocket.close();
+
+    // Stop the io_context to allow the server thread to exit
+    io.stop();
+    serverThread.join();
+    std::remove(socketPath.c_str());
+}
+
+} // namespace crow


### PR DESCRIPTION
This change adds support for handling HTTP-based Redfish requests over a UNIX domain socket instead of traditional TCP/IP.

Key additions:
- A local UNIX socket endpoint (e.g., /tmp/run/local_bmcweb.sock) to receive HTTP requests directly.
- Integration with existing RDE handlers to support Redfish PATCH/GET/POST operations over the socket.
- Updated connection handling to distinguish between remote (HTTPS) and local (UNIX) transport types.
- Support for local Redfish access used by the Cache Manager service and other internal components during host-off scenario

Tested:
Verified local Redfish PATCH and GET operations.

```
curl --unix-socket /tmp/run/local_bmcweb.sock http://127.0.0.1/redfish/v1/Systems/system/Processors/P0/Oem/AMD/SocConfiguration/Token
{
  "@odata.id": "/redfish/v1/Systems/system/Processors/P0",
  "@odata.type": "#ProcessorCollection.ProcessorCollection",
  "Members": [],
  "Members@odata.count": 0,
  "Name": "Processor Collection",
  "Payload": {
    "CbsCmnCpuCcd0DowncoreBitMap_0x071B74FD": 0,
    "CbsCmnCpuCcd1DowncoreBitMap_0xCF16A2FE": 0,
    "CbsCmnCpuCcd2DowncoreBitMap_0x23F46963": 0,
    "CbsCmnFchUsbXHCI1Enable_0xCBAA700B": 15,
    "CbsCmnMemBootTimePostPackageRepair_0xE2291E4A": 0,
    "CbsCpuPst0Fid_0x5EE89158": 16,
    "CbsCpuPst0Vid_0x45960E91": 0,
    "CbsCpuPstCustomP0_0x83CF6A10": 2,
    "CbsDbgFchRomArmorRom3BaseHighControl_0x957CCF70": 255,
    "CbsDbgFchRomArmorRom3BaseHigh_0x3E7D5274": 0
}
```