### PR TITLE
Return 204 No Content when power cap is unchecked

### DIFF
--- a/redfish-core/lib/power.hpp
+++ b/redfish-core/lib/power.hpp
@@ -86,8 +86,15 @@ inline void afterGetChassisPath(
     auto& item = powerControlCollections[0];
 
     std::optional<uint32_t> value;
-    if (!json_util::readJsonObject(item, sensorsAsyncResp->asyncResp->res,
-                                   "PowerLimit/LimitInWatts", value))
+
+    if (!item.contains("PowerLimit") ||
+        !item["PowerLimit"].contains("LimitInWatts") ||
+        item["PowerLimit"]["LimitInWatts"].is_null())
+    {
+        value = 0;
+    }
+    else if (!json_util::readJsonObject(item, sensorsAsyncResp->asyncResp->res,
+                                        "PowerLimit/LimitInWatts", value))
     {
         return;
     }
@@ -106,6 +113,9 @@ inline void afterGetChassisPath(
                             "/xyz/openbmc_project/control/host0/power_cap"),
                         "xyz.openbmc_project.Control.Power.Cap",
                         "PowerCapEnable", false);
+        sensorsAsyncResp->asyncResp->res.result(
+            boost::beast::http::status::no_content);
+        return;
     }
     else
     {


### PR DESCRIPTION
- When "Apply Power Cap" is unchecked in the UI, "PowerLimit/LimitInWatts" may be missing or null.

- Added explicit checks to handle this case and default `value` to 0.

- Ensured early return with HTTP 204 No Content to prevent backend from returning 400 Bad Request.

Tested fields: Tested in Congo platform.