### PR TITLE
redfish-core: message registry: added health-mgr

### DIFF
--- a/redfish-core/include/registries/openbmc_message_registry.hpp
+++ b/redfish-core/include/registries/openbmc_message_registry.hpp
@@ -609,6 +609,30 @@ static constexpr std::array registry =
             },
             "None.",
         }},
+        MessageEntry{
+            "GeneralHealthManagerError",
+            {
+                "Indicates a general amd-health-mgr error has occurred.",
+                "amd-health-mgr: %1.",
+                "Critical",
+                1,
+                {
+                    "string",
+                },
+                "None.",
+            }},
+        MessageEntry{
+            "GeneralHealthManagerInfo",
+            {
+                "Indicates a general amd-health-mgr informational log",
+                "amd-health-mgr: %1.",
+                "OK",
+                1,
+                {
+                    "string",
+                },
+                "None.",
+            }},
     MessageEntry{
         "IPMIWatchdog",
         {


### PR DESCRIPTION
redfish-core: message registry: added health-mgr

Added health-mgr to SEL message registry for
errors and informational logs

Tested:
- Verified in Kenya