### PR TITLE
bmcweb: POST Code support for Multi-host

### DIFF
--- a/redfish-core/lib/systems_logservices_postcodes.hpp
+++ b/redfish-core/lib/systems_logservices_postcodes.hpp
@@ -121,6 +121,19 @@ inline void handleSystemsLogServicesPostCodesPost(
     }
     BMCWEB_LOG_DEBUG("Do delete all postcodes entries.");
 
+    uint8_t hostNumber = getUrlHostNumber(req);
+    if (hostNumber > 2)
+    {
+        messages::actionParameterNotSupported(
+            asyncResp->res, std::to_string(hostNumber), "HostNumber");
+    }
+
+    std::string service =
+        "xyz.openbmc_project.State.Boot.PostCode" + std::to_string(hostNumber);
+
+    std::string objectPath =
+        "/xyz/openbmc_project/State/Boot/PostCode" + std::to_string(hostNumber);
+
     // Make call to post-code service to request clear all
     dbus::utility::async_method_call(
         asyncResp,
@@ -137,9 +150,8 @@ inline void handleSystemsLogServicesPostCodesPost(
             }
             messages::success(asyncResp->res);
         },
-        "xyz.openbmc_project.State.Boot.PostCode0",
-        "/xyz/openbmc_project/State/Boot/PostCode0",
-        "xyz.openbmc_project.Collection.DeleteAll", "DeleteAll");
+        service, objectPath, "xyz.openbmc_project.Collection.DeleteAll",
+        "DeleteAll");
 }
 
 /**
@@ -323,7 +335,7 @@ static bool fillPostCodeEntry(
 
 inline void getPostCodeForEntry(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& entryId)
+    const std::string& entryId, uint8_t hostNumber)
 {
     uint16_t bootIndex = 0;
     uint64_t codeIndex = 0;
@@ -340,6 +352,12 @@ inline void getPostCodeForEntry(
         messages::resourceNotFound(asyncResp->res, "LogEntry", entryId);
         return;
     }
+
+    std::string service =
+        "xyz.openbmc_project.State.Boot.PostCode" + std::to_string(hostNumber);
+
+    std::string objectPath =
+        "/xyz/openbmc_project/State/Boot/PostCode" + std::to_string(hostNumber);
 
     dbus::utility::async_method_call(
         asyncResp,
@@ -367,24 +385,28 @@ inline void getPostCodeForEntry(
                 return;
             }
         },
-        "xyz.openbmc_project.State.Boot.PostCode0",
-        "/xyz/openbmc_project/State/Boot/PostCode0",
-        "xyz.openbmc_project.State.Boot.PostCode", "GetPostCodesWithTimeStamp",
-        bootIndex);
+        service, objectPath, "xyz.openbmc_project.State.Boot.PostCode",
+        "GetPostCodesWithTimeStamp", bootIndex);
 }
 
 inline void getPostCodeForBoot(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const uint16_t bootIndex, const uint16_t bootCount,
-    const uint64_t entryCount, size_t skip, size_t top)
+    const uint64_t entryCount, size_t skip, size_t top, uint8_t hostNumber)
 {
+    std::string service =
+        "xyz.openbmc_project.State.Boot.PostCode" + std::to_string(hostNumber);
+
+    std::string objectPath =
+        "/xyz/openbmc_project/State/Boot/PostCode" + std::to_string(hostNumber);
+
     dbus::utility::async_method_call(
         asyncResp,
-        [asyncResp, bootIndex, bootCount, entryCount, skip,
-         top](const boost::system::error_code& ec,
-              const boost::container::flat_map<
-                  uint64_t, std::tuple<std::vector<uint8_t>,
-                                       std::vector<uint8_t>>>& postcode) {
+        [asyncResp, bootIndex, bootCount, entryCount, skip, top, hostNumber](
+            const boost::system::error_code& ec,
+            const boost::container::flat_map<
+                uint64_t, std::tuple<std::vector<uint8_t>,
+                                     std::vector<uint8_t>>>& postcode) {
             if (ec)
             {
                 BMCWEB_LOG_DEBUG("DBUS POST CODE PostCode response error");
@@ -416,7 +438,7 @@ inline void getPostCodeForBoot(
             {
                 getPostCodeForBoot(asyncResp,
                                    static_cast<uint16_t>(bootIndex + 1),
-                                   bootCount, endCount, skip, top);
+                                   bootCount, endCount, skip, top, hostNumber);
             }
             else if (skip + top < endCount)
             {
@@ -427,30 +449,34 @@ inline void getPostCodeForBoot(
                     std::to_string(skip + top);
             }
         },
-        "xyz.openbmc_project.State.Boot.PostCode0",
-        "/xyz/openbmc_project/State/Boot/PostCode0",
-        "xyz.openbmc_project.State.Boot.PostCode", "GetPostCodesWithTimeStamp",
-        bootIndex);
+        service, objectPath, "xyz.openbmc_project.State.Boot.PostCode",
+        "GetPostCodesWithTimeStamp", bootIndex);
 }
 
 inline void getCurrentBootNumber(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp, size_t skip,
-    size_t top)
+    size_t top, uint8_t hostNumber)
 {
     uint64_t entryCount = 0;
+    std::string service =
+        "xyz.openbmc_project.State.Boot.PostCode" + std::to_string(hostNumber);
+
+    std::string objectPath =
+        "/xyz/openbmc_project/State/Boot/PostCode" + std::to_string(hostNumber);
+
     dbus::utility::getProperty<uint16_t>(
-        "xyz.openbmc_project.State.Boot.PostCode0",
-        "/xyz/openbmc_project/State/Boot/PostCode0",
-        "xyz.openbmc_project.State.Boot.PostCode", "CurrentBootCycleCount",
-        [asyncResp, entryCount, skip,
-         top](const boost::system::error_code& ec, const uint16_t bootCount) {
+        service, objectPath, "xyz.openbmc_project.State.Boot.PostCode",
+        "CurrentBootCycleCount",
+        [asyncResp, entryCount, skip, top, hostNumber](
+            const boost::system::error_code& ec, const uint16_t bootCount) {
             if (ec)
             {
                 BMCWEB_LOG_DEBUG("DBUS response error {}", ec);
                 messages::internalError(asyncResp->res);
                 return;
             }
-            getPostCodeForBoot(asyncResp, 1, bootCount, entryCount, skip, top);
+            getPostCodeForBoot(asyncResp, 1, bootCount, entryCount, skip, top,
+                               hostNumber);
         });
 }
 
@@ -483,6 +509,14 @@ inline void handleSystemsLogServicesPostCodesEntriesGet(
                                    systemName);
         return;
     }
+
+    uint8_t hostNumber = getUrlHostNumber(req);
+    if (hostNumber > 2)
+    {
+        messages::actionParameterNotSupported(
+            asyncResp->res, std::to_string(hostNumber), "HostNumber");
+    }
+
     asyncResp->res.jsonValue["@odata.type"] =
         "#LogEntryCollection.LogEntryCollection";
     asyncResp->res.jsonValue["@odata.id"] =
@@ -495,7 +529,7 @@ inline void handleSystemsLogServicesPostCodesEntriesGet(
     asyncResp->res.jsonValue["Members@odata.count"] = 0;
     size_t skip = delegatedQuery.skip.value_or(0);
     size_t top = delegatedQuery.top.value_or(query_param::Query::maxTop);
-    getCurrentBootNumber(asyncResp, skip, top);
+    getCurrentBootNumber(asyncResp, skip, top, hostNumber);
 }
 
 inline void handleSystemsLogServicesPostCodesEntriesEntryAdditionalDataGet(
@@ -535,6 +569,19 @@ inline void handleSystemsLogServicesPostCodesEntriesEntryAdditionalDataGet(
         messages::resourceNotFound(asyncResp->res, "LogEntry", postCodeID);
         return;
     }
+
+    uint8_t hostNumber = getUrlHostNumber(req);
+    if (hostNumber > 2)
+    {
+        messages::actionParameterNotSupported(
+            asyncResp->res, std::to_string(hostNumber), "HostNumber");
+    }
+
+    std::string service =
+        "xyz.openbmc_project.State.Boot.PostCode" + std::to_string(hostNumber);
+
+    std::string objectPath =
+        "/xyz/openbmc_project/State/Boot/PostCode" + std::to_string(hostNumber);
 
     dbus::utility::async_method_call(
         asyncResp,
@@ -582,9 +629,8 @@ inline void handleSystemsLogServicesPostCodesEntriesEntryAdditionalDataGet(
                 boost::beast::http::field::content_transfer_encoding, "Base64");
             asyncResp->res.write(crow::utility::base64encode(strData));
         },
-        "xyz.openbmc_project.State.Boot.PostCode0",
-        "/xyz/openbmc_project/State/Boot/PostCode0",
-        "xyz.openbmc_project.State.Boot.PostCode", "GetPostCodes", index);
+        service, objectPath, "xyz.openbmc_project.State.Boot.PostCode",
+        "GetPostCodes", index);
 }
 
 inline void handleSystemsLogServicesPostCodesEntriesEntryGet(
@@ -610,7 +656,13 @@ inline void handleSystemsLogServicesPostCodesEntriesEntryGet(
         return;
     }
 
-    getPostCodeForEntry(asyncResp, targetID);
+    uint8_t hostNumber = getUrlHostNumber(req);
+    if (hostNumber > 2)
+    {
+        messages::actionParameterNotSupported(
+            asyncResp->res, std::to_string(hostNumber), "HostNumber");
+    }
+    getPostCodeForEntry(asyncResp, targetID, hostNumber);
 }
 
 inline void requestRoutesSystemsLogServicesPostCode(App& app)


### PR DESCRIPTION
Add support to enable POST codes in a multi-host
scenario. Following are the Redfish API calls.

```
    - GET https://<ip>/redfish/v1/Systems/system/LogServices/
                       PostCodes/Entries/?HostNumber=<host numbner>

    - POST https://<ip>/redfish/v1/Systems/system/LogServices/
                    PostCodes/Actions/LogService.ClearLog/?HostNumber=<host number>
```

Tested fields: Verified using morocco platform.