### PR TITLE
add support for MCA UMC error threshold config

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -3508,6 +3508,7 @@ inline void requestRoutesCrashdumpConfig(App& app)
             std::optional<int64_t> PcieAerPollingPeriod;
             std::optional<int64_t> DramCeccErrThresholdCnt;
             std::optional<int64_t> McaErrThresholdCnt;
+            std::optional<int64_t> McaUmcErrThresholdCnt;
             std::optional<int64_t> PcieAerErrThresholdCnt;
 
             if (!redfish::json_util::readJsonAction(
@@ -3528,6 +3529,7 @@ inline void requestRoutesCrashdumpConfig(App& app)
                     "PcieAerPollingPeriod", PcieAerPollingPeriod,
                     "DramCeccErrThresholdCnt", DramCeccErrThresholdCnt,
                     "McaErrThresholdCnt", McaErrThresholdCnt,
+                    "McaUmcErrThresholdCnt", McaUmcErrThresholdCnt,
                     "PcieAerErrThresholdCnt", PcieAerErrThresholdCnt))
             {
                 return;
@@ -3854,6 +3856,22 @@ inline void requestRoutesCrashdumpConfig(App& app)
                     serviceName, "/com/amd/RAS", "com.amd.RAS.Configuration",
                     "SetAttribute", "McaErrThresholdCnt",
                     std::variant<int64_t>(*McaErrThresholdCnt));
+            }
+            if (McaUmcErrThresholdCnt)
+            {
+                crow::connections::systemBus->async_method_call(
+                    [asyncResp](const boost::system::error_code ec) {
+                        if (ec)
+                        {
+                            messages::internalError(asyncResp->res);
+                            return;
+                        }
+                        messages::success(asyncResp->res);
+                        return;
+                    },
+                    serviceName, "/com/amd/RAS", "com.amd.RAS.Configuration",
+                    "SetAttribute", "McaUmcErrThresholdCnt",
+                    std::variant<int64_t>(*McaUmcErrThresholdCnt));
             }
             if (PcieAerErrThresholdCnt)
             {


### PR DESCRIPTION
This change extends the Redfish Crashdump configuration API to support setting the MCA UMC error threshold count.

This enables remote configuration of MCA UMC error threshold handling through Redfish, ensuring consistency with existing RAS threshold controls exposed for MCA and PCIe AER errors.

Tests:
Able to get and set MAC UMC error threshold config via redfish.

'''
curl -s -k -u root:0penBmc -H "Content-type: application/json" -X PATCH https://<bmc_ip>/redfish/v1/Systems/system/LogSActions/Oem/Crashdump.Configuration -d '{"McaUmcErrThresholdCnt": 2}' {
  "@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The request completed successfully.",
      "MessageArgs": [],
      "MessageId": "Base.1.19.Success",
      "MessageSeverity": "OK",
      "Resolution": "None."
    }
  ]
}
'''