### PR TITLE
bmcweb: Fix Storage URI Endpoint Failure

### DIFF
--- a/redfish-core/lib/storage.hpp
+++ b/redfish-core/lib/storage.hpp
@@ -473,21 +473,8 @@ inline void getDriveItemProperties(
                         return;
                     }
 
-                    std::optional<drive::MediaType> mediaType =
-                        convertDriveType(*value);
-                    if (!mediaType)
-                    {
-                        BMCWEB_LOG_WARNING("UnknownDriveType Interface: {}",
-                                           *value);
-                        continue;
-                    }
-                    if (*mediaType == drive::MediaType::Invalid)
-                    {
-                        messages::internalError(asyncResp->res);
-                        return;
-                    }
-
-                    asyncResp->res.jsonValue["MediaType"] = *mediaType;
+                    // read type value direct from Bios
+                    asyncResp->res.jsonValue["MediaType"] = *value;
                 }
                 else if (propertyName == "Capacity")
                 {


### PR DESCRIPTION
During BMC Upstream sync from 2.16 to 2.18, lead to failure of logic to read Type property for Drive URI. Moved the code to be similar as before where Type property is read directly from the string literal exposed on dbus by iodevices-inventory.

Tested: tested On congo UI. Storage info is populated without any internal error.

'''
{
"@odata.id": "/redfish/v1/Systems/system/Storage/1/Drives/Drive0", "@odata.type": "#Drive.v1_7_0.Drive",
"CapacityBytes": 1000204886016,
"Id": "Drive0",
"Links": {
"Chassis": {
"@odata.id": "/redfish/v1/Chassis/HPM"
}
},
"Manufacturer": "Samsung SSD 990 EVO 1TB ",
"MediaType": "NVMe",
"Model": "Samsung SSD 990 EVO 1TB ",
"Name": "Drive0",
"SerialNumber": "S7M3NS0Y215061W ",
"Status": {
"State": "Enabled"
}
}
'''