### PR TITLE
bmcweb: Add 'revision' for Storage URI

### DIFF
--- a/redfish-core/lib/storage.hpp
+++ b/redfish-core/lib/storage.hpp
@@ -311,11 +311,12 @@ inline void getDriveAsset(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
             const std::string* serialNumber = nullptr;
             const std::string* manufacturer = nullptr;
             const std::string* model = nullptr;
+            const std::string* revision = nullptr;
 
             const bool success = sdbusplus::unpackPropertiesNoThrow(
                 dbus_utils::UnpackErrorPrinter(), propertiesList, "PartNumber",
                 partNumber, "SerialNumber", serialNumber, "Manufacturer",
-                manufacturer, "Model", model);
+                manufacturer, "Model", model, "Revision", revision);
 
             if (!success)
             {
@@ -341,6 +342,11 @@ inline void getDriveAsset(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
             if (model != nullptr)
             {
                 asyncResp->res.jsonValue["Model"] = *model;
+            }
+
+            if (revision != nullptr)
+            {
+                asyncResp->res.jsonValue["Revision"] = *revision;
             }
         });
 }


### PR DESCRIPTION
revision was missing from the Storage Info.
Added the code to fetch revision.

Tested: On Congo. Revision is fetched.

'''

{
"@odata.id": "/redfish/v1/Systems/system/Storage/1/Drives/Drive0", "@odata.type": "#Drive.v1_7_0.Drive",
"CapacityBytes": 1000204886016,
"Id": "Drive0",
"Links": {
"Chassis": {
"@odata.id": "/redfish/v1/Chassis/HPM"
}
},
"Manufacturer": "Samsung SSD 990 EVO 1TB ",
"MediaType": "NVMe",
"Model": "Samsung SSD 990 EVO 1TB ",
"Name": "Drive0",
"Revision": "0B2QKXJ7",
"SerialNumber": "S7M3NS0Y210852A ",
"Status": {
"State": "Enabled"
}
}

'''