### PR TITLE
Gracefully handle event entry parse failure

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -1637,14 +1637,11 @@ inline void handleSystemsLogServiceEventLogLogEntryCollection(
             nlohmann::json::object_t bmcLogEntry;
             LogParseError status =
                 fillEventLogEntryJson(idStr, logEntry, bmcLogEntry);
-            if (status == LogParseError::messageIdNotInRegistry)
-            {
-                continue;
-            }
+            // In the event that a line can't be parse, skip it as not to
+            // prevent later events from being shown
             if (status != LogParseError::success)
             {
-                messages::internalError(asyncResp->res);
-                return;
+                continue;
             }
 
             entryCount++;
@@ -1979,13 +1976,11 @@ inline void handleSystemsLogServiceEventLogEntriesGet(
                 nlohmann::json::object_t bmcLogEntry;
                 LogParseError status =
                     fillEventLogEntryJson(idStr, logEntry, bmcLogEntry);
-                if (status != LogParseError::success)
+                if (status == LogParseError::success)
                 {
-                    messages::internalError(asyncResp->res);
+                    asyncResp->res.jsonValue.update(bmcLogEntry);
                     return;
                 }
-                asyncResp->res.jsonValue.update(bmcLogEntry);
-                return;
             }
         }
     }


### PR DESCRIPTION
In the event that there is a invalid event line in `/var/log/redfish*`, calling `/redfish/v1/Systems/system/LogServices/EventLog/Entries` will result in an internal service error.

Skip over these invalid lines when found instead of throwing an internal service error.

Ignoring these malformed line should be harmless as this already occurs when an unknown message ID is found.

Tested:
Verified that event log file with invalid event line does not return internal error.