### PR TITLE
bmcweb: Fix LTPC connection handling

### DIFF
--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -209,7 +209,7 @@ class Connection :
     {
         BMCWEB_LOG_DEBUG("{} Connection started, total {}", logPtr(this),
                          connectionCount);
-        if (connectionCount >= 200)
+        if (connectionCount > 200)
         {
             BMCWEB_LOG_CRITICAL("{} Max connection count exceeded.",
                                 logPtr(this));
@@ -798,6 +798,7 @@ class Connection :
         if (ec)
         {
             BMCWEB_LOG_DEBUG("{} from write(2)", logPtr(this));
+            gracefulClose();
             return;
         }
 


### PR DESCRIPTION
 Summary:

- Fix an off-by-one error in the HTTPS connection limit check.
- Allow exactly 200 active HTTPS connections before rejecting new requests.
- Close connections on write failures to release connection slots promptly.

Problem:

During LTPC stress testing, WebUI and Redfish became unresponsive while SSH remained accessible because bmcweb rejected new HTTPS connections after reaching its internal connection limit.

Root Cause:

- `connectionCount` is incremented before the limit check, causing the 200th connection to be rejected due to an off-by-one condition.
- Write failures could delay connection cleanup, causing connection slots to remain occupied longer than necessary.

Validation:

- Built successfully.
- Verified the connection limit check allows exactly 200 active HTTPS connections.
- Verified connections are closed on write failures.