### PR TITLE
bmcweb: firmware inventory: fallback when host BIOS version unknown

### DIFF
--- a/redfish-core/lib/update_service.hpp
+++ b/redfish-core/lib/update_service.hpp
@@ -1327,7 +1327,18 @@ inline void getSoftwareVersion(
                 if (hostVersions != nullptr &&
                     hostNumber < hostVersions->size())
                 {
-                    version = &(*hostVersions)[hostNumber];
+                    const std::string& hostVersion = (*hostVersions)[hostNumber];
+                    if (!hostVersion.empty() &&
+                        !bmcweb::asciiIEquals(hostVersion, "Unknown"))
+                    {
+                        version = &hostVersion;
+                    }
+                    else
+                    {
+                        BMCWEB_LOG_DEBUG(
+                            "HostVersions[{}] is empty/Unknown, using default BIOS Version",
+                            hostNumber);
+                    }
                 }
             }
 


### PR DESCRIPTION
Keep HostVersions multi-host behavior, but fall back to the base Version when the selected host entry is empty or reports Unknown to avoid parity regressions.


Change-Id: I7c98a0f424b3497c44122c91f7e4d8ab7f7a6d32