### PR TITLE
Use getSubTreePaths to obtain fan objects that have interface

### DIFF
--- a/redfish-core/lib/fan.hpp
+++ b/redfish-core/lib/fan.hpp
@@ -36,7 +36,7 @@
 namespace redfish
 {
 constexpr std::array<std::string_view, 1> fanInterface = {
-    "xyz.openbmc_project.Inventory.Item.Fan"};
+    "xyz.openbmc_project.Sensor.Value"};
 
 inline void updateFanList(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -65,16 +65,13 @@ inline void updateFanList(
 
 inline void getFanPaths(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& validChassisPath,
+    const std::string& /* validChassisPath */,
     const std::function<void(const dbus::utility::MapperGetSubTreePathsResponse&
                                  fanPaths)>& callback)
 {
-    sdbusplus::message::object_path endpointPath{validChassisPath};
-    endpointPath /= "cooled_by";
-
-    dbus::utility::getAssociatedSubTreePaths(
-        endpointPath,
-        sdbusplus::message::object_path("/xyz/openbmc_project/inventory"), 0,
+    dbus::utility::getSubTreePaths(
+        "/xyz/openbmc_project/sensors/fan_tach",
+        0,
         fanInterface,
         [asyncResp, callback](
             const boost::system::error_code& ec,


### PR DESCRIPTION
    Use getSubTreePaths to obtain fan objects that have interface
    xyz.openbmc_project.Sensor.Value using Object Mapper.

    These fan objects are created under service
    xyz.openbmc_project.FanSensor

    With the current version of Entity Manager, it does not
    have support for D-Bus interfaces "Associations" such as
    cooled_by and it does not support "Exposes" within
    "Type": "Chassis"


Tested: On congo